### PR TITLE
Revamp home shell for responsive casino UI

### DIFF
--- a/src/lib/components/home/CommunityRail.svelte
+++ b/src/lib/components/home/CommunityRail.svelte
@@ -1,101 +1,111 @@
 <script lang="ts">
-        import { communityMessages, pushCommunityMessage, rainPot } from '$lib/stores/homepage';
-        import { Button } from '$lib/components/ui';
-        import { CloudRain, Send, Users } from 'lucide-svelte';
+	import { communityMessages, pushCommunityMessage, rainPot } from '$lib/stores/homepage';
+	import { Button } from '$lib/components/ui';
+	import { CloudRain, Send, Users } from 'lucide-svelte';
 
-        const messages = $derived($communityMessages);
-        const currentPot = $derived($rainPot);
-        let input = $state('');
+	const messages = $derived($communityMessages);
+	const currentPot = $derived($rainPot);
+	let input = $state('');
 
-        function sendMessage() {
-                const trimmed = input.trim();
-                if (!trimmed) return;
-                pushCommunityMessage({ username: 'Guest', message: trimmed });
-                input = '';
-        }
+	function sendMessage() {
+		const trimmed = input.trim();
+		if (!trimmed) return;
+		pushCommunityMessage({ username: 'Guest', message: trimmed });
+		input = '';
+	}
 
-        function handleSubmit(event: SubmitEvent) {
-                event.preventDefault();
-                sendMessage();
-        }
+	function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		sendMessage();
+	}
 
-        function handleKey(event: KeyboardEvent) {
-                if (event.key === 'Enter' && !event.shiftKey) {
-                        event.preventDefault();
-                        sendMessage();
-                }
-        }
+	function handleKey(event: KeyboardEvent) {
+		if (event.key === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			sendMessage();
+		}
+	}
 </script>
 
-<aside class="hidden xl:flex xl:w-[320px] xl:flex-col xl:border-l xl:border-border/60 xl:bg-surface/70 xl:backdrop-blur-sm">
-        <div class="border-border/60 flex items-center justify-between border-b px-5 py-4">
-                <div>
-                        <p class="text-xs uppercase tracking-[0.3em] text-muted-foreground">Community</p>
-                        <p class="text-sm font-semibold">Live chat feed</p>
-                </div>
-                <span class="border-primary/60 bg-primary/10 text-primary flex h-9 w-9 items-center justify-center rounded-xl border font-semibold">
-                        💬
-                </span>
-        </div>
+<aside class="hidden xl:flex xl:w-[300px] xl:flex-col xl:gap-5 xl:pt-6 xl:pr-4 xl:pl-6">
+	<div class="flex items-center justify-between">
+		<div>
+			<p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">Community</p>
+			<p class="text-foreground text-sm font-semibold">Trading floor chat</p>
+		</div>
+		<span
+			class="bg-primary/15 text-primary flex h-9 w-9 items-center justify-center rounded-xl font-semibold"
+			>💬</span
+		>
+	</div>
 
-        <div class="border-border/60 mx-5 mt-5 rounded-2xl border bg-gradient-to-br from-primary/25 via-primary/10 to-transparent p-4 shadow-[0_18px_40px_rgba(59,130,246,0.15)]">
-                <div class="flex items-center gap-3">
-                        <span class="border-white/40 bg-white/20 flex h-11 w-11 items-center justify-center rounded-xl border">
-                                <CloudRain class="h-5 w-5" />
-                        </span>
-                        <div>
-                                <p class="text-xs uppercase tracking-[0.3em] text-white/70">Rain pot</p>
-                                <p class="text-lg font-semibold text-white">{currentPot.total}</p>
-                        </div>
-                </div>
-                <div class="mt-4 flex items-center justify-between text-white/75">
-                        <div class="flex items-center gap-2 text-xs uppercase tracking-[0.3em]">
-                                <Users class="h-3.5 w-3.5" />
-                                {currentPot.contributors} in
-                        </div>
-                        <span class="text-xs uppercase tracking-[0.3em]">Ends in {currentPot.endsIn}</span>
-                </div>
-        </div>
+	<div
+		class="border-primary/20 from-primary/15 via-primary/5 rounded-3xl border bg-gradient-to-br to-transparent p-5 shadow-[0_18px_45px_rgba(12,74,110,0.25)] backdrop-blur"
+	>
+		<div class="flex items-center gap-3">
+			<span
+				class="flex h-12 w-12 items-center justify-center rounded-xl border border-white/25 bg-white/10 text-white"
+			>
+				<CloudRain class="h-5 w-5" />
+			</span>
+			<div>
+				<p class="text-xs tracking-[0.3em] text-white/70 uppercase">Rain pot</p>
+				<p class="text-xl font-semibold text-white">{currentPot.total}</p>
+			</div>
+		</div>
+		<div
+			class="mt-4 flex items-center justify-between text-[11px] tracking-[0.3em] text-white/70 uppercase"
+		>
+			<span class="flex items-center gap-2"
+				><Users class="h-3.5 w-3.5" /> {currentPot.contributors} online</span
+			>
+			<span>Ends in {currentPot.endsIn}</span>
+		</div>
+	</div>
 
-        <div class="marketplace-scrollbar mt-6 flex-1 space-y-3 overflow-y-auto px-5">
-                {#each messages as message}
-                        <article class="border-border/60 bg-surface-muted/40 rounded-2xl border px-4 py-3 text-sm">
-                                <div class="mb-1 flex items-center justify-between text-xs text-muted-foreground">
-                                        <div class="flex items-center gap-2">
-                                                <span class="text-foreground font-medium">{message.username}</span>
-                                                {#if message.badge}
-                                                        <span class={`rounded-full px-2 py-0.5 text-[10px] uppercase tracking-[0.3em] ${
-                                                                message.badge === 'vip'
-                                                                        ? 'bg-primary/20 text-primary'
-                                                                        : message.badge === 'staff'
-                                                                                ? 'bg-accent/20 text-accent-foreground'
-                                                                                : 'bg-secondary/20 text-secondary-foreground'
-                                                        }`}
-                                                        >{message.badge}</span
-                                                        >
-                                                {/if}
-                                        </div>
-                                        <span>{message.timestamp}</span>
-                                </div>
-                                <p class="leading-relaxed text-foreground/90">{message.message}</p>
-                        </article>
-                {/each}
-        </div>
-
-        <div class="border-border/60 border-t px-5 py-4">
-                <form class="flex items-center gap-2" onsubmit={handleSubmit}>
-                        <label class="sr-only" for="community-message">Message</label>
-                        <input
-                                id="community-message"
-                                class="border-border/60 bg-surface-muted/50 text-foreground placeholder:text-muted-foreground h-11 flex-1 rounded-xl border px-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-ring/50"
-                                placeholder="Share a drop..."
-                                bind:value={input}
-                                onkeydown={handleKey}
-                        />
-                        <Button size="sm" class="px-3" type="submit">
-                                <Send class="h-4 w-4" />
-                                <span class="sr-only">Send</span>
-                        </Button>
-                </form>
-        </div>
+	<div class="marketplace-scrollbar flex-1 space-y-3 overflow-y-auto pr-1">
+		{#each messages as message}
+			<article
+				class="border-border/40 bg-surface/70 rounded-2xl border px-4 py-3 text-sm shadow-[0_10px_30px_rgba(15,23,42,0.2)]"
+			>
+				<div
+					class="text-muted-foreground mb-1 flex items-center justify-between text-[11px] tracking-[0.3em] uppercase"
+				>
+					<div class="flex items-center gap-2 text-xs normal-case">
+						<span class="text-foreground font-semibold">{message.username}</span>
+						{#if message.badge}
+							<span
+								class={`rounded-full px-2 py-0.5 text-[10px] tracking-[0.3em] uppercase ${
+									message.badge === 'vip'
+										? 'bg-primary/20 text-primary'
+										: message.badge === 'staff'
+											? 'bg-accent/20 text-accent-foreground'
+											: 'bg-secondary/20 text-secondary-foreground'
+								}`}>{message.badge}</span
+							>
+						{/if}
+					</div>
+					<span class="text-[11px] normal-case">{message.timestamp}</span>
+				</div>
+				<p class="text-foreground/90 text-sm leading-relaxed">{message.message}</p>
+			</article>
+		{/each}
+	</div>
+	<form
+		class="border-border/40 bg-surface/80 flex items-center gap-2 rounded-2xl border px-4 py-3"
+		onsubmit={handleSubmit}
+	>
+		<label class="sr-only" for="community-message">Message</label>
+		<input
+			id="community-message"
+			class="text-foreground placeholder:text-muted-foreground h-10 flex-1 border-0 bg-transparent text-sm focus:outline-none"
+			placeholder="Share a drop..."
+			bind:value={input}
+			onkeydown={handleKey}
+		/>
+		<Button size="icon" variant="secondary" class="h-9 w-9 rounded-full" type="submit">
+			<Send class="h-4 w-4" />
+			<span class="sr-only">Send</span>
+		</Button>
+	</form>
 </aside>

--- a/src/lib/components/home/HeroCarousel.svelte
+++ b/src/lib/components/home/HeroCarousel.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { heroPromotions } from '$lib/stores/homepage';
+	import { Button, Badge } from '$lib/components/ui';
+	import { ChevronLeft, ChevronRight } from 'lucide-svelte';
+
+	const slides = $derived($heroPromotions);
+	let activeIndex = $state(0);
+	let timer: ReturnType<typeof setInterval> | null = null;
+
+	function goTo(index: number) {
+		activeIndex = index;
+		startTimer();
+	}
+
+	function step(direction: 1 | -1) {
+		const nextIndex = (activeIndex + direction + slides.length) % slides.length;
+		goTo(nextIndex);
+	}
+
+	function startTimer() {
+		stopTimer();
+		if (!slides.length) return;
+		timer = setInterval(() => {
+			activeIndex = (activeIndex + 1) % slides.length;
+		}, 6500);
+	}
+
+	function stopTimer() {
+		if (timer) {
+			clearInterval(timer);
+			timer = null;
+		}
+	}
+
+	onMount(() => {
+		startTimer();
+		return () => stopTimer();
+	});
+</script>
+
+{#if slides.length}
+	<section
+		class="border-border/70 bg-surface/70 relative overflow-hidden rounded-[32px] border shadow-[0_28px_120px_rgba(15,23,42,0.35)]"
+	>
+		<div
+			class="relative grid min-h-[420px] gap-10 overflow-hidden lg:grid-cols-[1.2fr,0.8fr]"
+			style={`background:${slides[activeIndex]?.background ?? 'var(--surface)'}`}
+		>
+			<div class="relative flex flex-col justify-between p-8 sm:p-12">
+				<div class="space-y-6 text-white">
+					<div class="flex flex-wrap items-center gap-3">
+						<Badge
+							variant="outline"
+							class="border-white/40 bg-white/10 text-xs tracking-[0.35em] uppercase"
+						>
+							{slides[activeIndex].tag}
+						</Badge>
+						<span class="text-xs text-white/70 sm:text-sm">{slides[activeIndex].subtitle}</span>
+					</div>
+					<div class="space-y-4">
+						<h1 class="text-3xl leading-tight font-semibold sm:text-4xl lg:text-5xl">
+							{slides[activeIndex].title}
+						</h1>
+						<p class="max-w-2xl text-sm leading-relaxed text-white/80 sm:text-base">
+							{slides[activeIndex].description}
+						</p>
+					</div>
+					<div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+						{#each slides[activeIndex].ctas as cta}
+							<Button
+								variant={cta.variant ?? 'default'}
+								class={`${
+									cta.variant === 'outline'
+										? 'border-white/70 bg-transparent text-white hover:bg-white/10'
+										: 'bg-white text-slate-900 hover:bg-white/90'
+								} w-full sm:w-auto`}
+							>
+								{cta.label}
+							</Button>
+						{/each}
+					</div>
+				</div>
+
+				<div
+					class="grid gap-4 rounded-3xl border border-white/20 bg-black/20 p-6 text-white/80 backdrop-blur"
+				>
+					<div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+						{#each slides[activeIndex].stats as stat}
+							<div class="rounded-2xl border border-white/15 bg-white/5 px-4 py-3 text-center">
+								<p class="text-[11px] tracking-[0.3em] text-white/60 uppercase">{stat.label}</p>
+								<p class="mt-1 text-lg font-semibold">{stat.value}</p>
+							</div>
+						{/each}
+					</div>
+				</div>
+			</div>
+
+			<aside class="relative hidden h-full flex-col gap-4 border-l border-white/15 p-6 lg:flex">
+				<div class="flex items-center justify-between text-white/80">
+					<p class="text-xs tracking-[0.35em] uppercase">Now trending</p>
+					<div class="flex gap-2">
+						<button
+							class="h-10 w-10 rounded-full border border-white/30 text-white/70 transition hover:border-white/60 hover:text-white/90 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+							type="button"
+							onclick={() => step(-1)}
+							aria-label="Previous slide"
+						>
+							<ChevronLeft class="h-4 w-4" />
+						</button>
+						<button
+							class="h-10 w-10 rounded-full border border-white/30 text-white/70 transition hover:border-white/60 hover:text-white/90 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+							type="button"
+							onclick={() => step(1)}
+							aria-label="Next slide"
+						>
+							<ChevronRight class="h-4 w-4" />
+						</button>
+					</div>
+				</div>
+				<div class="marketplace-scrollbar flex-1 space-y-3 overflow-y-auto pr-1">
+					{#each slides as slide, index}
+						<button
+							type="button"
+							class={`w-full rounded-2xl border px-4 py-3 text-left transition ${
+								index === activeIndex
+									? 'border-white/40 bg-white/10 text-white shadow-lg'
+									: 'border-transparent bg-white/5 text-white/70 hover:border-white/20 hover:text-white'
+							}`}
+							onclick={() => goTo(index)}
+						>
+							<p class="text-[11px] tracking-[0.3em] uppercase">{slide.tag}</p>
+							<p class="mt-2 text-sm font-semibold">{slide.title}</p>
+							<p class="text-xs text-white/60">{slide.subtitle}</p>
+						</button>
+					{/each}
+				</div>
+				<div class="flex items-center justify-center gap-2">
+					{#each slides as _, index}
+						<span
+							class={`h-1.5 rounded-full transition-all ${
+								index === activeIndex ? 'w-8 bg-white' : 'w-3 bg-white/40'
+							}`}
+						/>
+					{/each}
+				</div>
+			</aside>
+
+			<div
+				class="absolute inset-x-0 bottom-0 flex items-center justify-between gap-2 p-5 lg:hidden"
+			>
+				<button
+					class="h-10 w-10 rounded-full border border-white/30 text-white/70 transition hover:border-white/60 hover:text-white/90 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+					type="button"
+					onclick={() => step(-1)}
+					aria-label="Previous slide"
+				>
+					<ChevronLeft class="h-4 w-4" />
+				</button>
+				<div class="flex flex-1 justify-center gap-2">
+					{#each slides as _, index}
+						<span
+							class={`h-1.5 rounded-full transition-all ${
+								index === activeIndex ? 'w-8 bg-white' : 'w-3 bg-white/40'
+							}`}
+						/>
+					{/each}
+				</div>
+				<button
+					class="h-10 w-10 rounded-full border border-white/30 text-white/70 transition hover:border-white/60 hover:text-white/90 focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none"
+					type="button"
+					onclick={() => step(1)}
+					aria-label="Next slide"
+				>
+					<ChevronRight class="h-4 w-4" />
+				</button>
+			</div>
+		</div>
+	</section>
+{/if}

--- a/src/lib/components/home/KpiStrip.svelte
+++ b/src/lib/components/home/KpiStrip.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { marketplaceKpis } from '$lib/stores/homepage';
+
+	const kpis = $derived($marketplaceKpis);
+</script>
+
+<section class="grid gap-3 sm:grid-cols-3">
+	{#each kpis as kpi}
+		<article
+			class="border-border/70 bg-surface/70 flex flex-col gap-2 rounded-2xl border px-4 py-3 shadow-[0_12px_30px_rgba(15,23,42,0.25)]"
+		>
+			<p class="text-muted-foreground text-[11px] tracking-[0.3em] uppercase">{kpi.label}</p>
+			<div class="flex items-baseline justify-between">
+				<span class="text-foreground text-lg font-semibold">{kpi.value}</span>
+				<span
+					class={`text-xs font-semibold tracking-[0.3em] uppercase ${
+						kpi.tone === 'positive'
+							? 'text-success'
+							: kpi.tone === 'negative'
+								? 'text-destructive'
+								: 'text-muted-foreground'
+					}`}
+				>
+					{kpi.trend}
+				</span>
+			</div>
+		</article>
+	{/each}
+</section>

--- a/src/lib/components/home/MarketplaceGrid.svelte
+++ b/src/lib/components/home/MarketplaceGrid.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { marketplaceItems } from '$lib/stores/homepage';
+	import { Badge, Button } from '$lib/components/ui';
+	import { Eye, TrendingUp } from 'lucide-svelte';
+
+	const items = $derived($marketplaceItems);
+</script>
+
+<section class="space-y-5">
+	<div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+		<div class="space-y-1">
+			<h2 class="text-2xl font-semibold tracking-tight">Live Marketplace</h2>
+			<p class="text-muted-foreground text-sm">
+				Curated skins with instant liquidity and transparent asks.
+			</p>
+		</div>
+		<Button variant="outline" class="w-full gap-2 sm:w-auto">
+			<TrendingUp class="h-4 w-4" />
+			View analytics
+		</Button>
+	</div>
+
+	<div class="marketplace-scrollbar grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+		{#each items as item}
+			<article
+				class="border-border/70 bg-surface/70 hover:border-primary/60 relative overflow-hidden rounded-3xl border shadow-[0_18px_50px_rgba(15,23,42,0.35)] transition hover:-translate-y-1 hover:shadow-[0_28px_60px_rgba(12,74,110,0.45)]"
+			>
+				<div
+					class="relative h-32 w-full overflow-hidden rounded-3xl"
+					style={`background:${item.image}`}
+				>
+					<div
+						class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"
+					></div>
+					<div class="absolute top-5 left-5 flex items-center gap-2">
+						<Badge
+							variant="outline"
+							class="border-white/40 bg-white/10 text-xs tracking-[0.35em] text-white uppercase"
+						>
+							{item.rarity}
+						</Badge>
+					</div>
+				</div>
+				<div class="space-y-4 p-5">
+					<div>
+						<h3 class="text-base leading-snug font-semibold">{item.name}</h3>
+						<p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">
+							Volatility · {item.volatility}
+						</p>
+					</div>
+					<div class="flex items-center justify-between">
+						<div>
+							<p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">Current ask</p>
+							<p class="text-lg font-semibold">{item.price}</p>
+						</div>
+						<div
+							class="border-border/60 bg-surface-muted/60 text-muted-foreground flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium tracking-[0.3em] uppercase"
+						>
+							<Eye class="h-4 w-4" />
+							{item.watching}
+						</div>
+					</div>
+					<Button variant="secondary" class="w-full">Open details</Button>
+				</div>
+			</article>
+		{/each}
+	</div>
+</section>

--- a/src/lib/components/shell/BottomNav.svelte
+++ b/src/lib/components/shell/BottomNav.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { uiStore, toggleChat } from '$lib/stores/ui';
-	import { Home, AppWindow, MessageCircle, Package, User, LogIn } from 'lucide-svelte';
+	import { Home, Package, Swords, Briefcase } from 'lucide-svelte';
 	import { cn } from '$lib/utils';
 
 	interface BottomNavProps {
@@ -15,12 +14,11 @@
 		return $page.url.pathname === href;
 	}
 
-	const chatOpen = $derived($uiStore.chatOpen);
-
 	const items = [
 		{ href: '/', label: 'Home', icon: Home },
 		{ href: '/cases', label: 'Cases', icon: Package },
-		{ href: '/battles', label: 'Battles', icon: AppWindow }
+		{ href: '/battles', label: 'Battles', icon: Swords },
+		{ href: '/inventory', label: isAuthenticated ? 'Inventory' : 'Locker', icon: Briefcase }
 	];
 </script>
 
@@ -35,10 +33,10 @@
 		<a
 			href={item.href}
 			class={cn(
-				'text-muted-foreground duration-subtle ease-market-ease focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center gap-1 rounded-md px-2 py-2 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+				'text-muted-foreground duration-subtle ease-market-ease focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center gap-1 rounded-xl border border-transparent px-2 py-2 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
 				isActiveRoute(item.href)
-					? 'bg-surface-accent/20 text-foreground shadow-marketplace-sm border-primary/50 border'
-					: 'hover:border-border/60 hover:bg-surface-muted/40 hover:text-foreground border border-transparent'
+					? 'bg-surface-accent/20 text-foreground shadow-marketplace-sm border-primary/50'
+					: 'hover:border-border/60 hover:bg-surface-muted/40 hover:text-foreground'
 			)}
 			aria-current={isActiveRoute(item.href) ? 'page' : undefined}
 		>
@@ -46,38 +44,4 @@
 			<span>{item.label}</span>
 		</a>
 	{/each}
-
-	<button
-		class="text-muted-foreground duration-subtle ease-market-ease hover:border-border/60 hover:bg-surface-muted/40 hover:text-foreground focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center gap-1 rounded-md border border-transparent px-2 py-2 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-		onclick={toggleChat}
-		type="button"
-		aria-pressed={chatOpen}
-	>
-		<MessageCircle class="h-5 w-5" />
-		<span>Chat</span>
-	</button>
-
-	{#if isAuthenticated}
-		<a
-			href="/profile"
-			class={cn(
-				'text-muted-foreground duration-subtle ease-market-ease focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center gap-1 rounded-md border border-transparent px-2 py-2 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-				isActiveRoute('/profile')
-					? 'bg-surface-accent/20 text-foreground shadow-marketplace-sm border-primary/50 border'
-					: 'hover:border-border/60 hover:bg-surface-muted/40 hover:text-foreground'
-			)}
-			aria-current={isActiveRoute('/profile') ? 'page' : undefined}
-		>
-			<User class="h-5 w-5" />
-			<span>Profile</span>
-		</a>
-	{:else}
-		<a
-			href="/login"
-			class="border-border/60 bg-primary/15 text-primary duration-subtle ease-market-ease hover:bg-primary/25 focus-visible:ring-primary/60 focus-visible:ring-offset-background flex flex-1 flex-col items-center gap-1 rounded-md border px-2 py-2 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-		>
-			<LogIn class="h-5 w-5" />
-			<span>Sign In</span>
-		</a>
-	{/if}
 </nav>

--- a/src/lib/components/shell/Navbar.svelte
+++ b/src/lib/components/shell/Navbar.svelte
@@ -1,236 +1,176 @@
 <script lang="ts">
-        import {
-                Search,
-                Bell,
-                Menu,
-                X,
-                ChevronDown,
-                MessageCircle,
-                ShieldCheck,
-                Gift,
-                Settings
-        } from 'lucide-svelte';
-        import AuthButton from '$lib/components/AuthButton.svelte';
-        import {
-                Button,
-                DropdownMenu,
-                DropdownMenuTrigger,
-                DropdownMenuContent,
-                DropdownMenuItem,
-                DropdownMenuSeparator
-        } from '$lib/components/ui';
-        import { cn } from '$lib/utils';
-        import { uiStore, toggleChat } from '$lib/stores/ui';
+	import { Search, Bell, Menu, ChevronDown, MessageCircle, Gift } from 'lucide-svelte';
+	import AuthButton from '$lib/components/AuthButton.svelte';
+	import {
+		DropdownMenu,
+		DropdownMenuTrigger,
+		DropdownMenuContent,
+		DropdownMenuItem,
+		DropdownMenuSeparator
+	} from '$lib/components/ui';
+	import { cn } from '$lib/utils';
+	import { uiStore, toggleChat, toggleSidebar } from '$lib/stores/ui';
 
-        interface NavbarProps {
-                isAuthenticated?: boolean;
-                user?: {
-                        id: string;
-                        steamId: string;
-                        username: string;
-                        avatar?: string;
-                        balance: number;
-                        totalWagered: number;
-                        totalProfit: number;
-                        winRate: number;
-                        biggestWin: number;
-                        caseBattleWins: number;
-                } | null;
-                class?: string;
-        }
+	interface NavbarProps {
+		isAuthenticated?: boolean;
+		user?: {
+			id: string;
+			steamId: string;
+			username: string;
+			avatar?: string;
+			balance: number;
+			totalWagered: number;
+			totalProfit: number;
+			winRate: number;
+			biggestWin: number;
+			caseBattleWins: number;
+		} | null;
+		class?: string;
+	}
 
-        let { isAuthenticated = false, user, class: className = '' }: NavbarProps = $props();
+	let { isAuthenticated = false, user, class: className = '' }: NavbarProps = $props();
 
-        const userLevel = $derived(Math.floor((user?.totalWagered || 0) / 1000) + 1);
-        const chatOpen = $derived($uiStore.chatOpen);
-        let mobileMenuOpen = $state(false);
+	const userLevel = $derived(Math.floor((user?.totalWagered || 0) / 1000) + 1);
+	const chatOpen = $derived($uiStore.chatOpen);
 
-        const primaryNav = [
-                { label: 'Marketplace', href: '/' },
-                { label: 'Cases', href: '/cases' },
-                { label: 'Battles', href: '/battles' },
-                { label: 'Upgrades', href: '/upgrades' },
-                { label: 'Rewards', href: '/rewards' }
-        ];
-
-        function toggleMobileMenu() {
-                mobileMenuOpen = !mobileMenuOpen;
-        }
+	const primaryNav = [
+		{ label: 'Marketplace', href: '/' },
+		{ label: 'Cases', href: '/cases' },
+		{ label: 'Battles', href: '/battles' },
+		{ label: 'Upgrades', href: '/upgrades' },
+		{ label: 'Rewards', href: '/rewards' }
+	];
 </script>
 
 <nav
-        class={cn(
-                'border-border/60 bg-surface/80 sticky top-0 z-40 border-b backdrop-blur-xl shadow-[0_1px_0_0_rgba(148,163,184,0.08)]',
-                className
-        )}
+	class={cn(
+		'border-border/60 bg-surface/70 sticky top-0 z-50 w-full border-b shadow-[0_1px_0_rgba(148,163,184,0.15)] backdrop-blur-xl',
+		className
+	)}
 >
-        <div class="mx-auto flex w-full max-w-[1600px] flex-col gap-4 px-5 py-3">
-                <div class="flex items-center gap-4">
-                        <div class="flex flex-1 items-center gap-4">
-                                <a
-                                        href="/"
-                                        class="focus-visible:ring-ring/70 focus-visible:ring-offset-background flex items-center gap-3 text-left focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                                >
-                                        <div class="border-primary/40 bg-primary/15 text-primary shadow-marketplace-sm flex h-10 w-10 items-center justify-center rounded-xl border">
-                                                <span class="text-lg font-semibold tracking-tight">TR</span>
-                                        </div>
-                                        <div class="hidden flex-col lg:flex">
-                                                <span class="text-sm font-semibold">TopRoll</span>
-                                                <span class="text-muted-foreground/70 text-xs uppercase tracking-[0.35em]">Premium CS2</span>
-                                        </div>
-                                </a>
-                                <button
-                                        type="button"
-                                        class="border-border/60 bg-surface-muted/50 text-muted-foreground duration-subtle ease-market-ease hover:text-foreground focus-visible:ring-ring/60 inline-flex items-center rounded-md border px-3 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none lg:hidden"
-                                        onclick={toggleMobileMenu}
-                                        aria-label="Toggle navigation"
-                                        aria-expanded={mobileMenuOpen}
-                                        aria-controls="mobile-nav-panel"
-                                >
-                                        {#if mobileMenuOpen}
-                                                <X class="h-4 w-4" />
-                                        {:else}
-                                                <Menu class="h-4 w-4" />
-                                        {/if}
-                                </button>
+	<div class="mx-auto flex w-full max-w-none items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
+		<div class="flex flex-1 items-center gap-3">
+			<button
+				type="button"
+				class="border-border/60 bg-surface-muted/60 text-muted-foreground focus-visible:ring-ring/60 hover:text-foreground inline-flex h-10 w-10 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:outline-none xl:hidden"
+				onclick={toggleSidebar}
+				aria-label="Open navigation"
+			>
+				<Menu class="h-4 w-4" />
+			</button>
+			<a
+				href="/"
+				class="focus-visible:ring-ring/70 focus-visible:ring-offset-background flex items-center gap-3 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+			>
+				<div
+					class="border-primary/50 bg-primary/15 text-primary shadow-marketplace-sm flex h-10 w-10 items-center justify-center rounded-xl border font-semibold"
+				>
+					TR
+				</div>
+				<div class="hidden flex-col text-left md:flex">
+					<span class="text-sm font-semibold">TopRoll</span>
+					<span class="text-muted-foreground/70 text-xs tracking-[0.35em] uppercase"
+						>Premium CS2</span
+					>
+				</div>
+			</a>
+		</div>
 
-                                <nav class="hidden items-center gap-1 rounded-2xl border border-border/50 bg-surface-muted/40 p-1 lg:flex">
-                                        {#each primaryNav as link}
-                                                <a
-                                                        href={link.href}
-                                                        class="text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:ring-ring/60 focus-visible:ring-offset-background rounded-xl px-3 py-2 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                                                >
-                                                        {link.label}
-                                                </a>
-                                        {/each}
-                                </nav>
-                        </div>
+		<div class="hidden flex-1 justify-center xl:flex">
+			<nav
+				class="border-border/50 bg-surface-muted/40 flex items-center gap-1 rounded-full border px-2 py-1.5"
+				aria-label="Global"
+			>
+				{#each primaryNav as link}
+					<a
+						href={link.href}
+						class="text-muted-foreground hover:text-foreground focus-visible:ring-ring/60 focus-visible:ring-offset-background rounded-full px-4 py-1.5 text-sm font-medium transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+					>
+						{link.label}
+					</a>
+				{/each}
+			</nav>
+		</div>
 
-                        <div class="hidden flex-1 items-center gap-3 xl:flex">
-                                <label class="border-border/60 bg-surface-muted/60 text-muted-foreground focus-within:border-primary focus-within:ring-ring/40 flex w-full items-center gap-3 rounded-2xl border px-4 py-2 text-sm focus-within:ring-2">
-                                        <Search class="h-4 w-4" />
-                                        <input
-                                                type="search"
-                                                placeholder="Search skins, cases, or players"
-                                                class="text-foreground placeholder:text-muted-foreground h-9 flex-1 border-0 bg-transparent text-sm focus:outline-none"
-                                        />
-                                </label>
-                                <button
-                                        type="button"
-                                        class="border-border/60 bg-surface-muted/50 text-muted-foreground duration-subtle ease-market-ease hover:text-foreground focus-visible:ring-ring/60 focus-visible:ring-offset-background flex h-11 w-11 items-center justify-center rounded-xl border transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                                        aria-label="Notifications"
-                                >
-                                        <Bell class="h-4 w-4" />
-                                </button>
-                        </div>
+		<div class="flex flex-1 items-center justify-end gap-2 sm:gap-3">
+			<label
+				class="border-border/60 bg-surface-muted/60 text-muted-foreground focus-within:border-primary focus-within:ring-ring/40 hidden max-w-sm flex-1 items-center gap-3 rounded-full border px-4 py-2 text-sm focus-within:ring-2 lg:flex"
+			>
+				<Search class="h-4 w-4" />
+				<input
+					type="search"
+					placeholder="Search skins, cases, or players"
+					class="text-foreground placeholder:text-muted-foreground h-8 flex-1 border-0 bg-transparent text-sm focus:outline-none"
+				/>
+			</label>
+			<button
+				type="button"
+				class="border-border/60 bg-surface-muted/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring/60 focus-visible:ring-offset-background inline-flex h-10 w-10 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none lg:hidden"
+				aria-label="Search"
+			>
+				<Search class="h-4 w-4" />
+			</button>
+			<button
+				type="button"
+				class="border-border/60 bg-surface-muted/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring/60 focus-visible:ring-offset-background inline-flex h-10 w-10 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+				aria-label="Notifications"
+			>
+				<Bell class="h-4 w-4" />
+			</button>
+			<button
+				type="button"
+				class="border-border/60 bg-surface-muted/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring/60 focus-visible:ring-offset-background inline-flex h-10 w-10 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none xl:hidden"
+				aria-label="Toggle live chat"
+				onclick={toggleChat}
+				aria-pressed={chatOpen}
+			>
+				<MessageCircle class="h-4 w-4" />
+			</button>
 
-                        <div class="flex flex-1 items-center justify-end gap-3">
-                                <div class="border-border/60 bg-surface-muted/50 text-left rounded-2xl border px-4 py-3">
-                                        <p class="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">Balance</p>
-                                        <p class="text-sm font-semibold text-foreground">{user ? `$${user.balance.toLocaleString()}` : '$0.00'} <span class="text-muted-foreground text-xs font-normal">(demo)</span></p>
-                                </div>
-                                <button
-                                        type="button"
-                                        class="border-border/60 bg-surface-muted/50 text-muted-foreground duration-subtle ease-market-ease hover:text-foreground focus-visible:ring-ring/60 focus-visible:ring-offset-background hidden h-11 w-11 items-center justify-center rounded-xl border transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none lg:flex xl:hidden"
-                                        aria-label="Toggle live chat"
-                                        onclick={toggleChat}
-                                        aria-pressed={chatOpen}
-                                >
-                                        <MessageCircle class="h-4 w-4" />
-                                </button>
-
-                                {#if isAuthenticated && user}
-                                        <DropdownMenu>
-                                                <DropdownMenuTrigger
-                                                        class="group border-border/60 bg-surface-muted/40 duration-subtle ease-market-ease hover:border-primary/60 hover:bg-surface-muted/60 focus-visible:ring-ring/70 focus-visible:ring-offset-background inline-flex items-center gap-3 rounded-xl border px-2 py-1.5 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                                                >
-                                                        {#if user.avatar}
-                                                                <img src={user.avatar} alt={user.username} class="border-border/50 h-9 w-9 rounded-lg border object-cover" />
-                                                        {:else}
-                                                                <div class="border-border/60 bg-surface-muted/60 flex h-9 w-9 items-center justify-center rounded-lg border">
-                                                                        <ShieldCheck class="text-muted-foreground h-4 w-4" />
-                                                                </div>
-                                                        {/if}
-                                                        <div class="hidden text-left md:block">
-                                                                <p class="text-sm font-medium">{user.username}</p>
-                                                                <p class="text-muted-foreground text-xs">Level {userLevel}</p>
-                                                        </div>
-                                                        <ChevronDown class="text-muted-foreground duration-subtle ease-market-ease h-4 w-4 transition-transform group-aria-expanded:rotate-180" />
-                                                </DropdownMenuTrigger>
-                                                <DropdownMenuContent labelledby="user-menu">
-                                                        <div class="px-3 pt-1 pb-2">
-                                                                <p id="user-menu" class="text-muted-foreground text-xs uppercase tracking-[0.3em]">Signed in as</p>
-                                                                <p class="text-sm font-medium">{user.username}</p>
-                                                        </div>
-                                                        <DropdownMenuSeparator />
-                                                        <DropdownMenuItem onSelect={() => {}}>Profile Overview</DropdownMenuItem>
-                                                        <DropdownMenuItem onSelect={() => {}}>Inventory</DropdownMenuItem>
-                                                        <DropdownMenuItem onSelect={() => {}}>Case history</DropdownMenuItem>
-                                                        <DropdownMenuSeparator />
-                                                        <DropdownMenuItem onSelect={() => {}} class="text-destructive">Sign out</DropdownMenuItem>
-                                                </DropdownMenuContent>
-                                        </DropdownMenu>
-                                        <Button variant="secondary" class="hidden lg:flex gap-2">
-                                                <Gift class="h-4 w-4" />
-                                                Claim rewards
-                                        </Button>
-                                {:else}
-                                        <form method="POST" action="/api/auth/steam/login" class="hidden md:block">
-                                                <AuthButton class="bg-primary text-primary-foreground shadow-marketplace-md" />
-                                        </form>
-                                {/if}
-                        </div>
-                </div>
-
-                {#if mobileMenuOpen}
-                        <div
-                                id="mobile-nav-panel"
-                                class="border-border/60 bg-surface/80 text-sm rounded-2xl border p-4 shadow-marketplace-md lg:hidden"
-                        >
-                                <div class="space-y-3">
-                                        <label class="border-border/60 bg-surface-muted/60 text-muted-foreground focus-within:border-primary focus-within:ring-ring/40 flex w-full items-center gap-3 rounded-xl border px-3 py-2 text-sm focus-within:ring-2">
-                                                <Search class="h-4 w-4" />
-                                                <input
-                                                        type="search"
-                                                        placeholder="Search skins, cases, or players"
-                                                        class="text-foreground placeholder:text-muted-foreground h-9 flex-1 border-0 bg-transparent text-sm focus:outline-none"
-                                                />
-                                        </label>
-                                        <div class="grid gap-2">
-                                                {#each primaryNav as link}
-                                                        <a
-                                                                href={link.href}
-                                                                class="border-border/60 bg-surface-muted/40 text-foreground rounded-xl border px-3 py-2"
-                                                        >
-                                                                {link.label}
-                                                        </a>
-                                                {/each}
-                                        </div>
-                                        <div class="flex items-center justify-between rounded-xl border border-border/60 bg-surface-muted/40 px-3 py-2">
-                                                <div>
-                                                        <p class="text-[11px] uppercase tracking-[0.3em] text-muted-foreground">Balance</p>
-                                                        <p class="text-sm font-semibold text-foreground">{user ? `$${user.balance.toLocaleString()}` : '$0.00'}</p>
-                                                </div>
-                                                <button
-                                                        type="button"
-                                                        class="border-border/60 bg-surface-muted/60 text-muted-foreground duration-subtle ease-market-ease hover:text-foreground focus-visible:ring-ring/60 flex h-10 w-10 items-center justify-center rounded-lg border transition-colors focus-visible:ring-2 focus-visible:outline-none"
-                                                        onclick={toggleChat}
-                                                >
-                                                        <MessageCircle class="h-4 w-4" />
-                                                </button>
-                                        </div>
-                                        {#if !isAuthenticated}
-                                                <form method="POST" action="/api/auth/steam/login" class="w-full">
-                                                        <AuthButton class="w-full justify-center" />
-                                                </form>
-                                        {:else}
-                                                <Button variant="ghost" class="w-full justify-center gap-2">
-                                                        <Settings class="h-4 w-4" />
-                                                        Settings
-                                                </Button>
-                                        {/if}
-                                </div>
-                        </div>
-                {/if}
-        </div>
+			{#if isAuthenticated && user}
+				<DropdownMenu>
+					<DropdownMenuTrigger
+						class="group border-border/60 bg-surface-muted/50 hover:border-primary/60 hover:bg-surface-muted/70 focus-visible:ring-ring/70 focus-visible:ring-offset-background hidden items-center gap-3 rounded-xl border px-2 py-1.5 text-left transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none sm:flex"
+					>
+						{#if user.avatar}
+							<img src={user.avatar} alt={user.username} class="h-9 w-9 rounded-lg object-cover" />
+						{:else}
+							<div
+								class="border-border/60 bg-surface-muted/60 text-muted-foreground flex h-9 w-9 items-center justify-center rounded-lg border"
+							>
+								<Gift class="h-4 w-4" />
+							</div>
+						{/if}
+						<div class="hidden text-left lg:block">
+							<p class="text-sm font-medium">{user.username}</p>
+							<p class="text-muted-foreground text-xs">Level {userLevel}</p>
+						</div>
+						<ChevronDown
+							class="text-muted-foreground duration-200 group-aria-expanded:rotate-180"
+						/>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent labelledby="user-menu">
+						<div class="px-3 pt-1 pb-2">
+							<p id="user-menu" class="text-muted-foreground text-xs tracking-[0.3em] uppercase">
+								Signed in as
+							</p>
+							<p class="text-sm font-medium">{user.username}</p>
+						</div>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem onSelect={() => {}}>Profile overview</DropdownMenuItem>
+						<DropdownMenuItem onSelect={() => {}}>Inventory</DropdownMenuItem>
+						<DropdownMenuItem onSelect={() => {}}>Case history</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem onSelect={() => {}} class="text-destructive"
+							>Sign out</DropdownMenuItem
+						>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			{:else}
+				<form method="POST" action="/api/auth/steam/login" class="hidden sm:block">
+					<AuthButton class="bg-primary text-primary-foreground shadow-marketplace-md" />
+				</form>
+			{/if}
+		</div>
+	</div>
 </nav>

--- a/src/lib/components/shell/Sidebar.svelte
+++ b/src/lib/components/shell/Sidebar.svelte
@@ -17,13 +17,19 @@
 	} from 'lucide-svelte';
 	import { Button, Badge } from '$lib/components/ui';
 	import { cn } from '$lib/utils';
+	import { closeSidebar } from '$lib/stores/ui';
 
 	interface SidebarProps {
 		isAuthenticated?: boolean;
+		user?: {
+			username: string;
+			balance: number;
+			totalWagered: number;
+		} | null;
 		class?: string;
 	}
 
-	let { isAuthenticated = false, class: className = '' }: SidebarProps = $props();
+	let { isAuthenticated = false, user = null, class: className = '' }: SidebarProps = $props();
 
 	const navItems = [
 		{ href: '/', icon: Home, label: 'Home', description: 'Dashboard & stats' },
@@ -43,96 +49,120 @@
 	function isActiveRoute(href: string): boolean {
 		return $page.url.pathname === href;
 	}
+
+	function handleNavigation(href: string) {
+		goto(href);
+		closeSidebar();
+	}
 </script>
 
 <aside
-	class={cn(
-		'border-border/60 bg-surface/60 hidden h-full w-64 overflow-hidden border-r backdrop-blur-sm md:block',
-		className
-	)}
+	class={cn('bg-surface/70 flex h-full w-[240px] flex-none flex-col px-5 pt-8 pb-6', className)}
 >
-	<div class="flex h-full flex-col">
-		<div class="border-border/60 border-b px-6 py-5">
-			<p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">Navigation</p>
-		</div>
-
-		<nav class="flex-1 px-4 py-6" aria-label="Primary">
-			<ul class="space-y-1">
+	<div class="flex flex-col gap-6">
+		<div>
+			<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Main</p>
+			<nav class="mt-4 space-y-2" aria-label="Primary navigation">
 				{#each navItems as item}
-					<li>
-						<button
-							type="button"
-							class={cn(
-								'group duration-subtle ease-market-ease focus-visible:ring-ring/70 focus-visible:ring-offset-background flex w-full items-center justify-between rounded-md border border-transparent px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-								isActiveRoute(item.href)
-									? 'border-primary/60 bg-surface-accent/30 text-foreground shadow-marketplace-sm'
-									: 'text-muted-foreground hover:border-border/60 hover:bg-surface-muted/40 hover:text-foreground'
-							)}
-							onclick={() => goto(item.href)}
-							aria-current={isActiveRoute(item.href) ? 'page' : undefined}
-						>
-							<span class="flex items-center gap-3">
-								<span
-									class={cn(
-										'flex h-9 w-9 items-center justify-center rounded-md border',
-										isActiveRoute(item.href)
-											? 'border-primary/60 bg-primary/15 text-primary'
-											: 'border-border/50 bg-surface-muted/40 text-muted-foreground group-hover:text-foreground'
-									)}
-								>
-									<item.icon class="h-4 w-4" />
-								</span>
-								<span>
-									<span class="text-sm leading-tight font-medium">{item.label}</span>
-									<span class="text-muted-foreground/80 block text-xs">{item.description}</span>
-								</span>
+					<button
+						type="button"
+						class={cn(
+							'group flex w-full items-center justify-between rounded-2xl border border-transparent px-3 py-3 text-left transition duration-200',
+							'focus-visible:ring-ring/70 focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+							isActiveRoute(item.href)
+								? 'border-primary/60 bg-surface-accent/30 text-foreground shadow-marketplace-sm'
+								: 'text-muted-foreground hover:border-border/60 hover:bg-surface-muted/40 hover:text-foreground'
+						)}
+						onclick={() => handleNavigation(item.href)}
+						aria-current={isActiveRoute(item.href) ? 'page' : undefined}
+					>
+						<span class="flex items-center gap-3">
+							<span
+								class={cn(
+									'flex h-12 w-12 items-center justify-center rounded-xl border',
+									isActiveRoute(item.href)
+										? 'border-primary/60 bg-primary/15 text-primary'
+										: 'border-border/50 bg-surface-muted/40 text-muted-foreground group-hover:text-foreground'
+								)}
+							>
+								<item.icon class="h-4 w-4" />
 							</span>
-							{#if isActiveRoute(item.href)}
-								<Badge variant="outline" class="text-xs">Active</Badge>
-							{/if}
-						</button>
-					</li>
+							<span>
+								<span class="text-sm leading-tight font-semibold">{item.label}</span>
+								<span class="text-muted-foreground/75 block text-xs">{item.description}</span>
+							</span>
+						</span>
+						{#if isActiveRoute(item.href)}
+							<Badge
+								variant="outline"
+								class="rounded-full px-2 py-0.5 text-[10px] tracking-[0.3em] uppercase"
+								>Active</Badge
+							>
+						{/if}
+					</button>
 				{/each}
-			</ul>
-		</nav>
-
-		<div class="border-border/60 border-t px-4 py-5">
-			<p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">Support</p>
-                        <ul class="mt-3 space-y-2 text-sm">
-                                {#each supportItems as item}
-                                        <li>
-                                                <Button
-                                                        as="a"
-                                                        href={item.href}
-                                                        variant="outline"
-                                                        size="sm"
-                                                        class="border-border/60 bg-surface-muted/30 text-muted-foreground hover:text-foreground flex w-full items-center justify-start gap-3 rounded-lg"
-                                                >
-                                                        <span class="border-border/50 bg-surface-muted/50 flex h-8 w-8 items-center justify-center rounded-md border">
-                                                                <item.icon class="h-4 w-4" />
-                                                        </span>
-                                                        {item.label}
-                                                </Button>
-                                        </li>
-                                {/each}
-                        </ul>
+			</nav>
 		</div>
 
-		{#if !isAuthenticated}
-			<div class="border-border/60 border-t px-4 py-5">
-				<div
-					class="border-border/60 bg-surface-muted/40 text-muted-foreground rounded-lg border p-4 text-sm"
-				>
-					<p class="text-foreground font-medium">Sign in to unlock trading</p>
-					<p class="mt-1 text-xs">
-						Connect your Steam account to deposit, withdraw, and participate in battles.
-					</p>
-					<Button class="mt-4 w-full gap-2">
+		<div
+			class="border-border/40 bg-surface/80 rounded-3xl border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.25)]"
+		>
+			{#if isAuthenticated && user}
+				<div class="space-y-4">
+					<div>
+						<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Account</p>
+						<p class="mt-1 text-base font-semibold">{user.username}</p>
+					</div>
+					<div class="border-border/30 bg-surface-muted/40 space-y-3 rounded-2xl border p-4">
+						<div>
+							<p class="text-muted-foreground text-[11px] tracking-[0.3em] uppercase">Balance</p>
+							<p class="text-lg font-semibold">${user.balance.toLocaleString()}</p>
+						</div>
+						<div>
+							<p class="text-muted-foreground text-[11px] tracking-[0.3em] uppercase">
+								Total wagered
+							</p>
+							<p class="text-sm font-medium">${user.totalWagered.toLocaleString()}</p>
+						</div>
+						<Button variant="secondary" class="w-full">Manage funds</Button>
+					</div>
+				</div>
+			{:else}
+				<div class="space-y-4 text-sm">
+					<div>
+						<p class="text-foreground text-base font-semibold">Sign in to unlock trading</p>
+						<p class="text-muted-foreground text-xs leading-relaxed">
+							Connect your Steam account to deposit, withdraw, and battle with the floor.
+						</p>
+					</div>
+					<Button class="w-full gap-2">
 						<LogIn class="h-4 w-4" />
 						Sign in with Steam
 					</Button>
 				</div>
+			{/if}
+		</div>
+
+		<div class="border-border/40 bg-surface/60 rounded-3xl border p-4">
+			<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Support</p>
+			<div class="mt-3 grid gap-2">
+				{#each supportItems as item}
+					<Button
+						as="a"
+						href={item.href}
+						variant="ghost"
+						size="sm"
+						class="text-muted-foreground hover:text-foreground justify-start rounded-full px-3 py-2 text-sm"
+					>
+						<span
+							class="border-border/40 bg-surface-muted/40 mr-2 flex h-8 w-8 items-center justify-center rounded-full border"
+						>
+							<item.icon class="h-4 w-4" />
+						</span>
+						{item.label}
+					</Button>
+				{/each}
 			</div>
-		{/if}
+		</div>
 	</div>
 </aside>

--- a/src/lib/stores/homepage.ts
+++ b/src/lib/stores/homepage.ts
@@ -1,259 +1,296 @@
 import { readable, writable } from 'svelte/store';
 
 export type HeroPromotion = {
-        id: string;
-        title: string;
-        subtitle: string;
-        description: string;
-        tag: string;
-        highlight: string;
-        background: string;
-        ctas: { label: string; variant?: 'default' | 'secondary' | 'outline'; icon?: any }[];
-        stats: { label: string; value: string }[];
+	id: string;
+	title: string;
+	subtitle: string;
+	description: string;
+	tag: string;
+	highlight: string;
+	background: string;
+	ctas: { label: string; variant?: 'default' | 'secondary' | 'outline'; icon?: any }[];
+	stats: { label: string; value: string }[];
 };
 
 export type MarketplaceItem = {
-        id: string;
-        name: string;
-        image: string;
-        price: string;
-        rarity: 'Common' | 'Rare' | 'Epic' | 'Legendary';
-        volatility: string;
-        playersOnline: number;
+	id: string;
+	name: string;
+	image: string;
+	price: string;
+	rarity: 'Common' | 'Rare' | 'Epic' | 'Legendary';
+	volatility: 'Low' | 'Medium' | 'High' | 'Ultra' | 'Stable';
+	watching: number;
+};
+
+export type MarketplaceKpi = {
+	id: string;
+	label: string;
+	value: string;
+	trend: string;
+	tone: 'positive' | 'neutral' | 'negative';
 };
 
 export type CommunityPot = {
-        id: string;
-        title: string;
-        jackpot: string;
-        expiresIn: string;
-        participants: number;
-        variant: 'primary' | 'secondary' | 'accent';
-        streak?: string;
+	id: string;
+	title: string;
+	jackpot: string;
+	expiresIn: string;
+	participants: number;
+	variant: 'primary' | 'secondary' | 'accent';
+	streak?: string;
 };
 
 export type RainPot = {
-        total: string;
-        contributors: number;
-        endsIn: string;
+	total: string;
+	contributors: number;
+	endsIn: string;
 };
 
 export type CommunityMessage = {
-        id: string;
-        username: string;
-        message: string;
-        timestamp: string;
-        badge?: 'vip' | 'staff' | 'pro';
+	id: string;
+	username: string;
+	message: string;
+	timestamp: string;
+	badge?: 'vip' | 'staff' | 'pro';
 };
 
 export const heroPromotions = readable<HeroPromotion[]>([
-        {
-                id: 'doppler-bundle',
-                title: 'Neon Doppler Collection',
-                subtitle: 'Premium featured drop',
-                description:
-                        'Spin exclusive Doppler knives with a boosted legendary multiplier and transparent odds audited live.',
-                tag: 'Featured',
-                highlight: '3.8x legendary hits',
-                background: 'radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.65), transparent 55%), radial-gradient(circle at 80% 30%, rgba(6, 182, 212, 0.45), transparent 50%), rgba(17, 25, 40, 0.92)',
-                ctas: [
-                        { label: 'Open featured case', variant: 'default' },
-                        { label: 'Watch live drop', variant: 'outline' }
-                ],
-                stats: [
-                        { label: 'Live openings', value: '128' },
-                        { label: 'Top payout', value: '$14,920' },
-                        { label: 'Volatility', value: 'High' }
-                ]
-        },
-        {
-                id: 'high-roller',
-                title: 'High Roller Battles',
-                subtitle: 'Risk-on series',
-                description:
-                        'Queue into curated battle lobbies featuring transparent rake, auto-withdraw, and battle analytics.',
-                tag: 'Battles',
-                highlight: '2v2 · 4 case rotation',
-                background: 'radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.55), transparent 55%), radial-gradient(circle at 70% 70%, rgba(59, 130, 246, 0.35), transparent 50%), rgba(17, 24, 39, 0.9)',
-                ctas: [
-                        { label: 'Join lobby', variant: 'default' },
-                        { label: 'View battle stats', variant: 'outline' }
-                ],
-                stats: [
-                        { label: 'Lobbies live', value: '42' },
-                        { label: 'Average pot', value: '$3,280' },
-                        { label: 'Players queued', value: '168' }
-                ]
-        },
-        {
-                id: 'flash-cases',
-                title: 'Flash Drop Frenzy',
-                subtitle: 'Turbo cases',
-                description:
-                        'Grab time-limited flash cases with transparent edge and auto-withdraw to your locker in under 5 minutes.',
-                tag: 'Flash drop',
-                highlight: 'Ends in 02:19',
-                background: 'radial-gradient(circle at 15% 80%, rgba(253, 186, 116, 0.55), transparent 55%), radial-gradient(circle at 85% 20%, rgba(248, 113, 113, 0.45), transparent 50%), rgba(24, 24, 27, 0.92)',
-                ctas: [
-                        { label: 'Browse flash cases', variant: 'default' },
-                        { label: 'Set alert', variant: 'outline' }
-                ],
-                stats: [
-                        { label: 'Cases remaining', value: '312' },
-                        { label: 'Boosted odds', value: '+12%' },
-                        { label: 'Claimed today', value: '1,940' }
-                ]
-        }
+	{
+		id: 'doppler-bundle',
+		title: 'Neon Doppler Collection',
+		subtitle: 'Premium featured drop',
+		description:
+			'Spin exclusive Doppler knives with a boosted legendary multiplier and transparent odds audited live.',
+		tag: 'Featured',
+		highlight: '3.8x legendary hits',
+		background:
+			'radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.65), transparent 55%), radial-gradient(circle at 80% 30%, rgba(6, 182, 212, 0.45), transparent 50%), rgba(17, 25, 40, 0.92)',
+		ctas: [
+			{ label: 'Open featured case', variant: 'default' },
+			{ label: 'Watch live drop', variant: 'outline' }
+		],
+		stats: [
+			{ label: 'Live openings', value: '128' },
+			{ label: 'Top payout', value: '$14,920' },
+			{ label: 'Volatility', value: 'High' }
+		]
+	},
+	{
+		id: 'high-roller',
+		title: 'High Roller Battles',
+		subtitle: 'Risk-on series',
+		description:
+			'Queue into curated battle lobbies featuring transparent rake, auto-withdraw, and battle analytics.',
+		tag: 'Battles',
+		highlight: '2v2 · 4 case rotation',
+		background:
+			'radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.55), transparent 55%), radial-gradient(circle at 70% 70%, rgba(59, 130, 246, 0.35), transparent 50%), rgba(17, 24, 39, 0.9)',
+		ctas: [
+			{ label: 'Join lobby', variant: 'default' },
+			{ label: 'View battle stats', variant: 'outline' }
+		],
+		stats: [
+			{ label: 'Lobbies live', value: '42' },
+			{ label: 'Average pot', value: '$3,280' },
+			{ label: 'Players queued', value: '168' }
+		]
+	},
+	{
+		id: 'flash-cases',
+		title: 'Flash Drop Frenzy',
+		subtitle: 'Turbo cases',
+		description:
+			'Grab time-limited flash cases with transparent edge and auto-withdraw to your locker in under 5 minutes.',
+		tag: 'Flash drop',
+		highlight: 'Ends in 02:19',
+		background:
+			'radial-gradient(circle at 15% 80%, rgba(253, 186, 116, 0.55), transparent 55%), radial-gradient(circle at 85% 20%, rgba(248, 113, 113, 0.45), transparent 50%), rgba(24, 24, 27, 0.92)',
+		ctas: [
+			{ label: 'Browse flash cases', variant: 'default' },
+			{ label: 'Set alert', variant: 'outline' }
+		],
+		stats: [
+			{ label: 'Cases remaining', value: '312' },
+			{ label: 'Boosted odds', value: '+12%' },
+			{ label: 'Claimed today', value: '1,940' }
+		]
+	}
 ]);
 
 export const marketplaceItems = readable<MarketplaceItem[]>([
-        {
-                id: 'emerald-web',
-                name: '★ Karambit | Emerald Web',
-                image: 'radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.6), transparent 60%), radial-gradient(circle at 80% 80%, rgba(45, 212, 191, 0.4), transparent 55%), rgba(15, 23, 42, 0.9)',
-                price: '$7,820.00',
-                rarity: 'Legendary',
-                volatility: 'Ultra',
-                playersOnline: 38
-        },
-        {
-                id: 'dragon-lore',
-                name: 'AWP | Dragon Lore',
-                image: 'radial-gradient(circle at 30% 30%, rgba(245, 158, 11, 0.6), transparent 60%), radial-gradient(circle at 80% 60%, rgba(251, 191, 36, 0.45), transparent 55%), rgba(30, 41, 59, 0.92)',
-                price: '$4,510.00',
-                rarity: 'Legendary',
-                volatility: 'High',
-                playersOnline: 62
-        },
-        {
-                id: 'case-hard',
-                name: 'AK-47 | Case Hardened',
-                image: 'radial-gradient(circle at 25% 25%, rgba(59, 130, 246, 0.55), transparent 60%), radial-gradient(circle at 75% 75%, rgba(14, 165, 233, 0.45), transparent 55%), rgba(15, 23, 42, 0.9)',
-                price: '$850.90',
-                rarity: 'Epic',
-                volatility: 'Medium',
-                playersOnline: 104
-        },
-        {
-                id: 'printstream',
-                name: 'Desert Eagle | Printstream',
-                image: 'radial-gradient(circle at 20% 80%, rgba(244, 63, 94, 0.5), transparent 60%), radial-gradient(circle at 80% 20%, rgba(168, 85, 247, 0.45), transparent 55%), rgba(24, 24, 27, 0.92)',
-                price: '$315.00',
-                rarity: 'Epic',
-                volatility: 'Medium',
-                playersOnline: 91
-        },
-        {
-                id: 'case-spectrum',
-                name: 'Spectrum 2 Case',
-                image: 'radial-gradient(circle at 25% 25%, rgba(34, 197, 94, 0.5), transparent 60%), radial-gradient(circle at 70% 70%, rgba(74, 222, 128, 0.4), transparent 55%), rgba(17, 24, 39, 0.92)',
-                price: '$3.18',
-                rarity: 'Rare',
-                volatility: 'Low',
-                playersOnline: 402
-        },
-        {
-                id: 'recoil-case',
-                name: 'Recoil Case',
-                image: 'radial-gradient(circle at 30% 30%, rgba(99, 102, 241, 0.5), transparent 60%), radial-gradient(circle at 75% 65%, rgba(165, 180, 252, 0.4), transparent 55%), rgba(30, 41, 59, 0.92)',
-                price: '$1.92',
-                rarity: 'Rare',
-                volatility: 'Stable',
-                playersOnline: 356
-        },
-        {
-                id: 'stiletto',
-                name: '★ Stiletto Knife | Doppler',
-                image: 'radial-gradient(circle at 25% 25%, rgba(236, 72, 153, 0.55), transparent 60%), radial-gradient(circle at 75% 75%, rgba(129, 140, 248, 0.45), transparent 55%), rgba(24, 24, 27, 0.92)',
-                price: '$2,740.00',
-                rarity: 'Legendary',
-                volatility: 'Ultra',
-                playersOnline: 21
-        },
-        {
-                id: 'glove-case',
-                name: 'Clutch Case',
-                image: 'radial-gradient(circle at 25% 20%, rgba(248, 113, 113, 0.5), transparent 60%), radial-gradient(circle at 70% 75%, rgba(251, 146, 60, 0.4), transparent 55%), rgba(38, 38, 38, 0.9)',
-                price: '$2.45',
-                rarity: 'Common',
-                volatility: 'Low',
-                playersOnline: 518
-        }
+	{
+		id: 'emerald-web',
+		name: '★ Karambit | Emerald Web',
+		image:
+			'radial-gradient(circle at 20% 20%, rgba(16, 185, 129, 0.6), transparent 60%), radial-gradient(circle at 80% 80%, rgba(45, 212, 191, 0.4), transparent 55%), rgba(15, 23, 42, 0.9)',
+		price: '$7,820.00',
+		rarity: 'Legendary',
+		volatility: 'Ultra',
+		watching: 48
+	},
+	{
+		id: 'dragon-lore',
+		name: 'AWP | Dragon Lore',
+		image:
+			'radial-gradient(circle at 30% 30%, rgba(245, 158, 11, 0.6), transparent 60%), radial-gradient(circle at 80% 60%, rgba(251, 191, 36, 0.45), transparent 55%), rgba(30, 41, 59, 0.92)',
+		price: '$4,510.00',
+		rarity: 'Legendary',
+		volatility: 'High',
+		watching: 72
+	},
+	{
+		id: 'case-hard',
+		name: 'AK-47 | Case Hardened',
+		image:
+			'radial-gradient(circle at 25% 25%, rgba(59, 130, 246, 0.55), transparent 60%), radial-gradient(circle at 75% 75%, rgba(14, 165, 233, 0.45), transparent 55%), rgba(15, 23, 42, 0.9)',
+		price: '$850.90',
+		rarity: 'Epic',
+		volatility: 'Medium',
+		watching: 126
+	},
+	{
+		id: 'printstream',
+		name: 'Desert Eagle | Printstream',
+		image:
+			'radial-gradient(circle at 20% 80%, rgba(244, 63, 94, 0.5), transparent 60%), radial-gradient(circle at 80% 20%, rgba(168, 85, 247, 0.45), transparent 55%), rgba(24, 24, 27, 0.92)',
+		price: '$315.00',
+		rarity: 'Epic',
+		volatility: 'Medium',
+		watching: 88
+	},
+	{
+		id: 'case-spectrum',
+		name: 'Spectrum 2 Case',
+		image:
+			'radial-gradient(circle at 25% 25%, rgba(34, 197, 94, 0.5), transparent 60%), radial-gradient(circle at 70% 70%, rgba(74, 222, 128, 0.4), transparent 55%), rgba(17, 24, 39, 0.92)',
+		price: '$3.18',
+		rarity: 'Rare',
+		volatility: 'Low',
+		watching: 412
+	},
+	{
+		id: 'recoil-case',
+		name: 'Recoil Case',
+		image:
+			'radial-gradient(circle at 30% 30%, rgba(99, 102, 241, 0.5), transparent 60%), radial-gradient(circle at 75% 65%, rgba(165, 180, 252, 0.4), transparent 55%), rgba(30, 41, 59, 0.92)',
+		price: '$1.92',
+		rarity: 'Rare',
+		volatility: 'Stable',
+		watching: 365
+	},
+	{
+		id: 'stiletto',
+		name: '★ Stiletto Knife | Doppler',
+		image:
+			'radial-gradient(circle at 25% 25%, rgba(236, 72, 153, 0.55), transparent 60%), radial-gradient(circle at 75% 75%, rgba(129, 140, 248, 0.45), transparent 55%), rgba(24, 24, 27, 0.92)',
+		price: '$2,740.00',
+		rarity: 'Legendary',
+		volatility: 'Ultra',
+		watching: 29
+	},
+	{
+		id: 'glove-case',
+		name: 'Clutch Case',
+		image:
+			'radial-gradient(circle at 25% 20%, rgba(248, 113, 113, 0.5), transparent 60%), radial-gradient(circle at 70% 75%, rgba(251, 146, 60, 0.4), transparent 55%), rgba(38, 38, 38, 0.9)',
+		price: '$2.45',
+		rarity: 'Common',
+		volatility: 'Low',
+		watching: 524
+	}
+]);
+
+export const marketplaceKpis = readable<MarketplaceKpi[]>([
+	{
+		id: 'top-payout',
+		label: 'Top payout (24h)',
+		value: '$18,920',
+		trend: '+12%',
+		tone: 'positive'
+	},
+	{ id: 'live-openings', label: 'Live openings', value: '436', trend: 'Now', tone: 'neutral' },
+	{
+		id: 'volatility',
+		label: 'Volatility index',
+		value: 'High',
+		trend: '↑ Stable',
+		tone: 'positive'
+	}
 ]);
 export const communityPots = readable<CommunityPot[]>([
-        {
-                id: 'midnight-royale',
-                title: 'Midnight Royale',
-                jackpot: '$18,420',
-                expiresIn: '05:12',
-                participants: 186,
-                variant: 'primary',
-                streak: 'Hot streak 4x'
-        },
-        {
-                id: 'rainmaker',
-                title: 'Rainmaker',
-                jackpot: '$6,280',
-                expiresIn: '02:47',
-                participants: 94,
-                variant: 'accent'
-        },
-        {
-                id: 'phoenix-high',
-                title: 'Phoenix High Roll',
-                jackpot: '$42,960',
-                expiresIn: '14:58',
-                participants: 58,
-                variant: 'secondary',
-                streak: 'VIP access'
-        }
+	{
+		id: 'midnight-royale',
+		title: 'Midnight Royale',
+		jackpot: '$18,420',
+		expiresIn: '05:12',
+		participants: 186,
+		variant: 'primary',
+		streak: 'Hot streak 4x'
+	},
+	{
+		id: 'rainmaker',
+		title: 'Rainmaker',
+		jackpot: '$6,280',
+		expiresIn: '02:47',
+		participants: 94,
+		variant: 'accent'
+	},
+	{
+		id: 'phoenix-high',
+		title: 'Phoenix High Roll',
+		jackpot: '$42,960',
+		expiresIn: '14:58',
+		participants: 58,
+		variant: 'secondary',
+		streak: 'VIP access'
+	}
 ]);
 
 export const rainPot = readable<RainPot>({
-        total: '$12,400',
-        contributors: 312,
-        endsIn: '08:19'
+	total: '$12,400',
+	contributors: 312,
+	endsIn: '08:19'
 });
 
 const initialMessages: CommunityMessage[] = [
-        {
-                id: 'msg-01',
-                username: 'cypher',
-                message: 'Pulled a ★ Karambit | Doppler from Neon Doppler case!',
-                timestamp: 'just now',
-                badge: 'vip'
-        },
-        {
-                id: 'msg-02',
-                username: 'luna',
-                message: 'Anyone joining the Midnight Royale battle lobby?',
-                timestamp: '1m ago'
-        },
-        {
-                id: 'msg-03',
-                username: 'specter',
-                message: 'Rain pot is filling fast—20 slots left!',
-                timestamp: '3m ago',
-                badge: 'staff'
-        },
-        {
-                id: 'msg-04',
-                username: 'nova',
-                message: 'Sold Printstream instantly. Liquidity feels good today.',
-                timestamp: '5m ago'
-        }
+	{
+		id: 'msg-01',
+		username: 'cypher',
+		message: 'Pulled a ★ Karambit | Doppler from Neon Doppler case!',
+		timestamp: 'just now',
+		badge: 'vip'
+	},
+	{
+		id: 'msg-02',
+		username: 'luna',
+		message: 'Anyone joining the Midnight Royale battle lobby?',
+		timestamp: '1m ago'
+	},
+	{
+		id: 'msg-03',
+		username: 'specter',
+		message: 'Rain pot is filling fast—20 slots left!',
+		timestamp: '3m ago',
+		badge: 'staff'
+	},
+	{
+		id: 'msg-04',
+		username: 'nova',
+		message: 'Sold Printstream instantly. Liquidity feels good today.',
+		timestamp: '5m ago'
+	}
 ];
 
 export const communityMessages = writable<CommunityMessage[]>(initialMessages);
 
 export function pushCommunityMessage(message: Omit<CommunityMessage, 'id' | 'timestamp'>) {
-        const now = new Date();
-        communityMessages.update((messages) => [
-                ...messages,
-                {
-                        id: crypto.randomUUID(),
-                        timestamp: now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-                        ...message
-                }
-        ]);
+	const now = new Date();
+	communityMessages.update((messages) => [
+		...messages,
+		{
+			id: crypto.randomUUID(),
+			timestamp: now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+			...message
+		}
+	]);
 }

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -7,7 +7,7 @@ interface UIState {
 
 const initialState: UIState = {
 	chatOpen: false,
-	sidebarOpen: true
+	sidebarOpen: false
 };
 
 export const uiStore = writable<UIState>(initialState);
@@ -16,14 +16,22 @@ export function toggleChat() {
 	uiStore.update((state) => ({ ...state, chatOpen: !state.chatOpen }));
 }
 
-export function toggleSidebar() {
-	uiStore.update((state) => ({ ...state, sidebarOpen: !state.sidebarOpen }));
-}
-
 export function openChat() {
 	uiStore.update((state) => ({ ...state, chatOpen: true }));
 }
 
 export function closeChat() {
 	uiStore.update((state) => ({ ...state, chatOpen: false }));
+}
+
+export function toggleSidebar() {
+	uiStore.update((state) => ({ ...state, sidebarOpen: !state.sidebarOpen }));
+}
+
+export function openSidebar() {
+	uiStore.update((state) => ({ ...state, sidebarOpen: true }));
+}
+
+export function closeSidebar() {
+	uiStore.update((state) => ({ ...state, sidebarOpen: false }));
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,89 +5,69 @@
 	import Sidebar from '$lib/components/shell/Sidebar.svelte';
 	import BottomNav from '$lib/components/shell/BottomNav.svelte';
 	import ChatDrawer from '$lib/components/shell/ChatDrawer.svelte';
-import CommunityRail from '$lib/components/home/CommunityRail.svelte';
-	import { uiStore } from '$lib/stores/ui';
+	import CommunityRail from '$lib/components/home/CommunityRail.svelte';
+	import { MessageCircle } from 'lucide-svelte';
+	import { uiStore, closeSidebar, toggleChat } from '$lib/stores/ui';
 	import type { LayoutData } from './$types';
 
 	let { children, data }: { children: any; data: LayoutData } = $props();
 
 	const chatOpen = $derived($uiStore.chatOpen);
+	const sidebarOpen = $derived($uiStore.sidebarOpen);
 </script>
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
-<div class="mobile-viewport bg-background text-foreground">
-	<!-- Desktop Layout (1024px+) -->
-	<div class="hidden lg:flex lg:h-screen lg:flex-col">
-		<!-- Top Navbar -->
-		<Navbar isAuthenticated={data.isAuthenticated} user={data.user} />
+<div class="bg-background text-foreground relative flex min-h-screen flex-col">
+	<Navbar isAuthenticated={data.isAuthenticated} user={data.user} />
 
-		<!-- Main Content Area with Sidebar -->
-		<div class="flex flex-1 overflow-hidden">
-			<!-- Sidebar -->
-			<Sidebar isAuthenticated={data.isAuthenticated} class="w-64" />
+	<div class="flex flex-1">
+		<div class="border-border/60 xl:bg-surface/60 hidden xl:flex xl:border-r">
+			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full" />
+		</div>
 
-			<!-- Main Content -->
-			<main class="bg-background flex-1 overflow-y-auto">
-				<div class="mx-auto w-full max-w-7xl px-8 py-12 xl:px-12">
-					{@render children?.()}
-				</div>
-			</main>
+		<main class="flex-1 overflow-x-hidden">
+			<div
+				class="mx-auto w-full max-w-7xl px-5 pt-8 pb-24 sm:pt-10 sm:pb-16 md:px-8 lg:px-10 xl:px-12"
+			>
+				{@render children?.()}
+			</div>
+		</main>
 
-			<!-- Community Rail (Desktop Only) -->
+		<div class="hidden xl:block">
 			<CommunityRail />
-
-			<!-- Collapsible chat drawer for < xl -->
-			<ChatDrawer />
 		</div>
 	</div>
 
-	<!-- Tablet Layout (768px - 1023px) -->
-	<div class="hidden md:flex md:h-screen md:flex-col lg:hidden">
-		<!-- Top Navbar -->
-		<Navbar isAuthenticated={data.isAuthenticated} user={data.user} />
+	<BottomNav
+		isAuthenticated={data.isAuthenticated}
+		class="fixed inset-x-0 bottom-0 z-40 border-t pb-[env(safe-area-inset-bottom)] md:hidden"
+	/>
 
-		<!-- Main Content without Sidebar -->
-		<main class="bg-background flex-1 overflow-y-auto">
-			<div class="mx-auto w-full max-w-4xl px-6 py-10 lg:px-8">
-				{@render children?.()}
-			</div>
-		</main>
+	<button
+		type="button"
+		class="bg-primary text-primary-foreground shadow-marketplace-lg fixed right-4 bottom-20 z-40 flex h-12 w-12 items-center justify-center rounded-full md:hidden"
+		onclick={toggleChat}
+		aria-pressed={chatOpen}
+	>
+		<MessageCircle class="h-6 w-6" />
+		<span class="sr-only">Open chat</span>
+	</button>
 
-		<!-- Chat Sheet -->
-		<ChatDrawer />
-	</div>
+	<ChatDrawer />
 
-	<!-- Mobile Layout (< 768px) - Mobile First -->
-	<div class="flex h-screen flex-col md:hidden">
-		<!-- Mobile Header with Safe Area -->
-		<header class="pt-[env(safe-area-inset-top)]">
-			<Navbar isAuthenticated={data.isAuthenticated} user={data.user} class="min-h-[56px]" />
-		</header>
-
-		<!-- Main Content with Safe Scrolling -->
-		<main class="bg-background flex-1 overflow-y-auto overscroll-contain">
-			<div class="px-5 py-7 pb-28">
-				{@render children?.()}
-			</div>
-		</main>
-
-		<!-- Bottom Navigation with Safe Area -->
-		<div class="fixed right-0 bottom-0 left-0 z-50 pb-[env(safe-area-inset-bottom)]">
-			<BottomNav isAuthenticated={data.isAuthenticated} class="min-h-[64px]" />
-		</div>
-
-		<!-- Mobile Chat Drawer -->
-		<ChatDrawer />
-	</div>
-
-	<!-- Global Loading Overlay -->
-	{#if chatOpen}
+	{#if sidebarOpen}
 		<div
-			class="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm md:hidden"
+			class="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm xl:hidden"
 			role="presentation"
+			onclick={closeSidebar}
 		></div>
+		<div
+			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[260px] max-w-full overflow-y-auto px-5 pt-6 pb-8 backdrop-blur-xl xl:hidden"
+		>
+			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full" />
+		</div>
 	{/if}
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,264 +1,129 @@
 <script lang="ts">
-        import { page } from '$app/stores';
-        import HomeHero from '$lib/components/home/HomeHero.svelte';
-        import LiveMarketplaceGrid from '$lib/components/home/LiveMarketplaceGrid.svelte';
-        import CommunityPots from '$lib/components/home/CommunityPots.svelte';
-        import { openChat } from '$lib/stores/ui';
-        import {
-                AlertCircle,
-                Package,
-                Users,
-                TrendingUp,
-                Zap,
-                Shield,
-                RefreshCw,
-                MessageCircle,
-                Crown,
-                Sparkles
-        } from 'lucide-svelte';
-        import {
-                Alert,
-                Button,
-                Card,
-                CardContent,
-                CardHeader,
-                CardTitle,
-                CardDescription,
-                Badge
-        } from '$lib/components/ui';
+	import { page } from '$app/stores';
+	import HeroCarousel from '$lib/components/home/HeroCarousel.svelte';
+	import MarketplaceGrid from '$lib/components/home/MarketplaceGrid.svelte';
+	import KpiStrip from '$lib/components/home/KpiStrip.svelte';
+	import CommunityPots from '$lib/components/home/CommunityPots.svelte';
+	import { openChat } from '$lib/stores/ui';
+	import { AlertCircle, MessageCircle, Sparkles } from 'lucide-svelte';
+	import {
+		Alert,
+		Button,
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle,
+		CardDescription,
+		Badge
+	} from '$lib/components/ui';
 
-        interface Props {
-                data: any;
-        }
+	interface Props {
+		data: any;
+	}
 
-        let { data }: Props = $props();
+	let { data }: Props = $props();
 
-        const error = $page.url.searchParams.get('error');
+	const error = $page.url.searchParams.get('error');
 
-        const errorMessages: Record<string, { title: string; description: string; action?: string }> = {
-                auth_required: {
-                        title: 'Authentication Required',
-                        description: 'Please sign in with Steam to access your profile and inventory.',
-                        action: 'Sign In'
-                },
-                steam_auth_failed: {
-                        title: 'Steam Authentication Failed',
-                        description: 'There was a problem authenticating with Steam. Please try again.',
-                        action: 'Try Again'
-                },
-                steam_profile_not_found: {
-                        title: 'Steam Profile Not Found',
-                        description: "We couldn't find your Steam profile. Please make sure your profile is public.",
-                        action: 'Try Again'
-                },
-                config_error: {
-                        title: 'Configuration Error',
-                        description: "There's a temporary issue with our Steam integration. Please try again later.",
-                        action: 'Try Later'
-                },
-                auth_failed: {
-                        title: 'Authentication Failed',
-                        description: 'Something went wrong during authentication. Please try signing in again.',
-                        action: 'Try Again'
-                }
-        };
+	const errorMessages: Record<string, { title: string; description: string; action?: string }> = {
+		auth_required: {
+			title: 'Authentication Required',
+			description: 'Please sign in with Steam to access your profile and inventory.',
+			action: 'Sign In'
+		},
+		steam_auth_failed: {
+			title: 'Steam Authentication Failed',
+			description: 'There was a problem authenticating with Steam. Please try again.',
+			action: 'Try Again'
+		},
+		steam_profile_not_found: {
+			title: 'Steam Profile Not Found',
+			description: "We couldn't find your Steam profile. Please make sure your profile is public.",
+			action: 'Try Again'
+		},
+		config_error: {
+			title: 'Configuration Error',
+			description: "There's a temporary issue with our Steam integration. Please try again later.",
+			action: 'Try Later'
+		},
+		auth_failed: {
+			title: 'Authentication Failed',
+			description: 'Something went wrong during authentication. Please try signing in again.',
+			action: 'Try Again'
+		}
+	};
 
-        const currentError = error ? errorMessages[error] : null;
+	const currentError = error ? errorMessages[error] : null;
 
-        const marketPulse = [
-                {
-                        label: 'Cases opened today',
-                        value: '1,247',
-                        delta: '+6.2%',
-                        icon: Package,
-                        tone: 'text-primary'
-                },
-                {
-                        label: 'Active traders',
-                        value: '3,482',
-                        delta: '+18%',
-                        icon: Users,
-                        tone: 'text-accent-foreground'
-                },
-                {
-                        label: 'Total payouts 24h',
-                        value: '$128,440',
-                        delta: '+12%',
-                        icon: TrendingUp,
-                        tone: 'text-success'
-                }
-        ];
+	const flashUpdates = [
+		{ title: 'Rain pot slots nearly full', caption: '20 spots · $12.4k pool' },
+		{ title: 'VIP battle lobby spinning', caption: 'Avg pot $3.2k · invite only' },
+		{ title: 'Flash drop ends in 2m', caption: 'Boosted odds live' }
+	];
 
-        const quickActions = [
-                {
-                        title: 'Start a case battle lobby',
-                        description: 'Queue a 2v2 with curated case rotations and transparent rake.',
-                        action: 'Create lobby',
-                        icon: Crown
-                },
-                {
-                        title: 'Chat with the floor',
-                        description: 'Drop into the live chat to coordinate rain pot entries and flips.',
-                        action: 'Open chat',
-                        icon: MessageCircle,
-                        handler: openChat
-                }
-        ];
-
-        const flashUpdates = [
-                {
-                        title: 'Rain pot slots nearly full',
-                        caption: '20 spots remain · $12.4k total'
-                },
-                {
-                        title: 'Flash Drop Frenzy closes in 2m',
-                        caption: 'Boosted odds still active'
-                },
-                {
-                        title: 'VIP battle lobby spinning up',
-                        caption: 'Average pot $3.2k · invite only'
-                }
-        ];
+	const quickCtas = [
+		{ label: 'Launch battle lobby', icon: Sparkles, action: () => {} },
+		{ label: 'Open community chat', icon: MessageCircle, action: openChat }
+	];
 </script>
 
 <svelte:head>
-        <title>TopRoll - CS2 Marketplace</title>
+	<title>TopRoll - CS2 Marketplace</title>
 </svelte:head>
 
 <div class="space-y-12">
-        {#if currentError}
-                <Alert variant="destructive" class="items-start">
-                        <AlertCircle class="h-5 w-5" />
-                        <div class="space-y-2">
-                                <p class="text-sm font-semibold">{currentError.title}</p>
-                                <p class="text-muted-foreground text-sm">{currentError.description}</p>
-                                {#if currentError.action === 'Sign In'}
-                                        <form method="POST" action="/api/auth/steam/login">
-                                                <Button type="submit" size="sm" class="mt-1">
-                                                        <Shield class="h-4 w-4" />
-                                                        Sign in with Steam
-                                                </Button>
-                                        </form>
-                                {:else if currentError.action === 'Try Again'}
-                                        <form method="POST" action="/api/auth/steam/login">
-                                                <Button type="submit" variant="outline" size="sm" class="mt-1">
-                                                        <RefreshCw class="h-4 w-4" />
-                                                        Retry authentication
-                                                </Button>
-                                        </form>
-                                {/if}
-                        </div>
-                </Alert>
-        {/if}
+	{#if currentError}
+		<Alert variant="destructive" class="items-start">
+			<AlertCircle class="h-5 w-5" />
+			<div class="space-y-2">
+				<p class="text-sm font-semibold">{currentError.title}</p>
+				<p class="text-muted-foreground text-sm">{currentError.description}</p>
+				{#if currentError.action === 'Sign In'}
+					<form method="POST" action="/api/auth/steam/login">
+						<Button type="submit" size="sm" class="mt-1">Sign in with Steam</Button>
+					</form>
+				{:else if currentError.action === 'Try Again'}
+					<form method="POST" action="/api/auth/steam/login">
+						<Button type="submit" variant="outline" size="sm" class="mt-1"
+							>Retry authentication</Button
+						>
+					</form>
+				{/if}
+			</div>
+		</Alert>
+	{/if}
 
-        <HomeHero />
+	<HeroCarousel />
 
-        <section class="grid gap-6 xl:grid-cols-[1.35fr,1fr]">
-                <Card class="border-border/70 bg-surface/70 border">
-                        <CardHeader class="flex flex-col gap-2 border-b border-border/60 pb-6">
-                                <Badge variant="outline" class="w-fit">Marketplace pulse</Badge>
-                                <CardTitle class="text-2xl font-semibold">Live performance snapshot</CardTitle>
-                                <CardDescription>
-                                        Transparent metrics refreshed every 30 seconds to keep you ahead of the market.
-                                </CardDescription>
-                        </CardHeader>
-                        <CardContent class="grid gap-4 pt-6 sm:grid-cols-3">
-                                {#each marketPulse as pulse}
-                                        <div class="border-border/60 bg-surface-muted/40 rounded-2xl border p-5">
-                                                <div class="flex items-center gap-3">
-                                                        <span class={`border-border/60 bg-surface-muted/60 flex h-10 w-10 items-center justify-center rounded-xl border ${pulse.tone}`}>
-                                                                <pulse.icon class="h-5 w-5" />
-                                                        </span>
-                                                        <div>
-                                                                <p class="text-xs uppercase tracking-[0.3em] text-muted-foreground">{pulse.label}</p>
-                                                                <p class="text-lg font-semibold text-foreground">{pulse.value}</p>
-                                                        </div>
-                                                </div>
-                                                <p class="text-success mt-4 text-xs font-semibold uppercase tracking-[0.3em]">
-                                                        {pulse.delta}
-                                                </p>
-                                        </div>
-                                {/each}
-                        </CardContent>
-                </Card>
+	<section class="space-y-10">
+		<MarketplaceGrid />
+		<KpiStrip />
+	</section>
 
-                <Card class="border-border/70 bg-surface/70 flex flex-col gap-5 border p-6">
-                        <div>
-                                <CardTitle class="text-xl font-semibold">Quick actions</CardTitle>
-                                <CardDescription>Jump straight into the most used flows on the platform.</CardDescription>
-                        </div>
-                        <div class="space-y-3">
-                                {#each quickActions as action}
-                                        <div class="border-border/60 bg-surface-muted/40 rounded-2xl border p-4">
-                                                <div class="flex items-start justify-between gap-3">
-                                                        <div class="flex items-center gap-3">
-                                                                <span class="border-border/60 bg-surface-muted/60 flex h-10 w-10 items-center justify-center rounded-xl border">
-                                                                        <action.icon class="h-4 w-4" />
-                                                                </span>
-                                                                <div>
-                                                                        <p class="text-sm font-semibold">{action.title}</p>
-                                                                        <p class="text-muted-foreground text-xs leading-relaxed">{action.description}</p>
-                                                                </div>
-                                                        </div>
-                                                        <Button size="sm" variant="outline" onclick={action.handler ?? (() => {})}>
-                                                                {action.action}
-                                                        </Button>
-                                                </div>
-                                        </div>
-                                {/each}
-                        </div>
-
-                        <div class="border-border/60 bg-surface-muted/30 rounded-2xl border p-4">
-                                <div class="flex items-center gap-3">
-                                        <span class="border-border/60 bg-surface-muted/60 flex h-10 w-10 items-center justify-center rounded-xl border">
-                                                <Sparkles class="h-4 w-4" />
-                                        </span>
-                                        <div>
-                                                <p class="text-sm font-semibold">Weekly VIP rewards</p>
-                                                <p class="text-muted-foreground text-xs">Boosted rakeback cycles and private drop rooms.</p>
-                                        </div>
-                                </div>
-                        </div>
-                </Card>
-        </section>
-
-        <LiveMarketplaceGrid />
-
-        <section class="grid gap-8 xl:grid-cols-[1.4fr,1fr]">
-                <CommunityPots />
-                <Card class="border-border/70 bg-surface/70 flex flex-col border p-6">
-                        <CardHeader class="border-0 px-0 pt-0">
-                                <Badge variant="outline" class="w-fit">Live alerts</Badge>
-                                <CardTitle class="text-xl font-semibold">Trading floor updates</CardTitle>
-                                <CardDescription>Stay reactive with flash announcements from the operations desk.</CardDescription>
-                        </CardHeader>
-                        <CardContent class="space-y-4 px-0">
-                                {#each flashUpdates as update}
-                                        <div class="border-border/60 bg-surface-muted/40 rounded-2xl border p-4">
-                                                <p class="text-sm font-semibold">{update.title}</p>
-                                                <p class="text-muted-foreground text-xs">{update.caption}</p>
-                                        </div>
-                                {/each}
-                                <Button variant="outline" class="mt-2 gap-2" onclick={openChat}>
-                                        Join community chat
-                                        <MessageCircle class="h-4 w-4" />
-                                </Button>
-                        </CardContent>
-                </Card>
-        </section>
-
-        <Card class="border-border/70 bg-surface/70 border p-6">
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                                <CardTitle class="text-xl font-semibold">Provably fair & transparent</CardTitle>
-                                <CardDescription>
-                                        Every spin is verifiable with on-chain seeds, independent audits, and instant withdrawal coverage.
-                                </CardDescription>
-                        </div>
-                        <Badge variant="outline" class="gap-2 text-xs uppercase tracking-[0.3em]">
-                                <Zap class="h-4 w-4" />
-                                Certified fair play
-                        </Badge>
-                </div>
-        </Card>
+	<section class="grid gap-8 xl:grid-cols-[1.4fr,1fr]">
+		<CommunityPots />
+		<Card class="border-border/60 bg-surface/70 border">
+			<CardHeader class="gap-1">
+				<Badge variant="outline" class="w-fit">Trading floor</Badge>
+				<CardTitle class="text-xl font-semibold">Flash updates</CardTitle>
+				<CardDescription>Real-time signals from the operations desk.</CardDescription>
+			</CardHeader>
+			<CardContent class="space-y-4">
+				{#each flashUpdates as update}
+					<div class="border-border/60 bg-surface-muted/40 rounded-2xl border p-4">
+						<p class="text-sm font-semibold">{update.title}</p>
+						<p class="text-muted-foreground text-xs">{update.caption}</p>
+					</div>
+				{/each}
+				<div class="flex flex-wrap gap-3">
+					{#each quickCtas as cta}
+						<Button variant="secondary" class="gap-2" onclick={cta.action}>
+							<cta.icon class="h-4 w-4" />
+							{cta.label}
+						</Button>
+					{/each}
+				</div>
+			</CardContent>
+		</Card>
+	</section>
 </div>


### PR DESCRIPTION
## Summary
- Build a full-width hero carousel with supporting marketplace and KPI components to refresh the home experience.
- Redesign the navbar, sidebar, and layout to support pinned navigation, mobile drawers, and floating chat access.
- Extend homepage stores with richer mock data powering the updated marketplace cards and KPI strip.

## Testing
- pnpm lint *(fails: existing lint violations in legacy scripts/components)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f4a3fed483269b7ba0dcb9ca0b2b