### PR TITLE
Restore sticky desktop shell layout and hero marketplace stack

### DIFF
--- a/src/lib/components/home/CommunityPots.svelte
+++ b/src/lib/components/home/CommunityPots.svelte
@@ -1,78 +1,95 @@
 <script lang="ts">
-        import { communityPots } from '$lib/stores/homepage';
-        import { Badge, Button } from '$lib/components/ui';
-        import { ArrowRight, Crown, Users, Timer } from 'lucide-svelte';
+	import { communityPots } from '$lib/stores/homepage';
+	import { Badge, Button } from '$lib/components/ui';
+	import { ArrowRight, Crown, Users, Timer } from 'lucide-svelte';
 
-        const pots = $derived($communityPots);
+	const pots = $derived($communityPots);
 
-        const variantAccent = {
-                primary: 'from-primary/20 via-primary/10 to-transparent border-primary/50 shadow-[0_18px_40px_rgba(59,130,246,0.18)]',
-                secondary: 'from-secondary/20 via-secondary/10 to-transparent border-secondary/50 shadow-[0_18px_40px_rgba(14,165,233,0.18)]',
-                accent: 'from-accent/20 via-accent/10 to-transparent border-accent/50 shadow-[0_18px_40px_rgba(34,197,94,0.15)]'
-        } as const;
+	const variantAccent = {
+		primary:
+			'from-primary/20 via-primary/10 to-transparent border-primary/50 shadow-[0_18px_40px_rgba(59,130,246,0.18)]',
+		secondary:
+			'from-secondary/20 via-secondary/10 to-transparent border-secondary/50 shadow-[0_18px_40px_rgba(14,165,233,0.18)]',
+		accent:
+			'from-accent/20 via-accent/10 to-transparent border-accent/50 shadow-[0_18px_40px_rgba(34,197,94,0.15)]'
+	} as const;
 </script>
 
 <section class="space-y-6">
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-                        <div>
-                                <p class="text-xs uppercase tracking-[0.3em] text-muted-foreground">Community jackpots</p>
-                                <h2 class="text-2xl font-semibold">Community Pots</h2>
-                                <p class="text-muted-foreground text-sm">Track the biggest shared jackpots filling right now.</p>
-                        </div>
-                        <Button variant="outline" class="gap-2">
-                                Upcoming pots
-                                <ArrowRight class="h-4 w-4" />
-                        </Button>
-        </div>
-        <div class="grid gap-4 lg:grid-cols-3">
-                {#each pots as pot}
-                        <article class={`border-border/60 relative overflow-hidden rounded-3xl border bg-surface/80 p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-marketplace-lg`}>                        
-                                <div class={`absolute inset-0 bg-gradient-to-br ${variantAccent[pot.variant]}`} aria-hidden="true"></div>
-                                <div class="relative z-[1] flex flex-col gap-6">
-                                        <div class="flex items-center justify-between">
-                                                <div>
-                                                        <p class="text-xs uppercase tracking-[0.3em] text-white/70">{pot.title}</p>
-                                                        <h3 class="text-3xl font-semibold text-white">{pot.jackpot}</h3>
-                                                </div>
-                                                <span class="border-white/30 bg-black/30 text-white/80 flex h-12 w-12 items-center justify-center rounded-2xl border">
-                                                        <Crown class="h-5 w-5" />
-                                                </span>
-                                        </div>
-                                        <div class="flex items-center justify-between gap-3">
-                                                <div class="flex items-center gap-3 text-white/80">
-                                                        <span class="border-white/30 bg-black/30 flex h-10 w-10 items-center justify-center rounded-xl border">
-                                                                <Timer class="h-4 w-4" />
-                                                        </span>
-                                                        <div>
-                                                                <p class="text-[11px] uppercase tracking-[0.3em] text-white/60">Ends in</p>
-                                                                <p class="text-sm font-medium">{pot.expiresIn}</p>
-                                                        </div>
-                                                </div>
-                                                <div class="flex items-center gap-3 text-white/80">
-                                                        <span class="border-white/30 bg-black/30 flex h-10 w-10 items-center justify-center rounded-xl border">
-                                                                <Users class="h-4 w-4" />
-                                                        </span>
-                                                        <div>
-                                                                <p class="text-[11px] uppercase tracking-[0.3em] text-white/60">Participants</p>
-                                                                <p class="text-sm font-medium">{pot.participants}</p>
-                                                        </div>
-                                                </div>
-                                        </div>
-                                        <div class="flex items-center justify-between">
-                                                {#if pot.streak}
-                                                        <Badge variant="secondary" class="bg-black/30 text-white/80 border-white/20 uppercase tracking-[0.3em] text-[10px]">
-                                                                {pot.streak}
-                                                        </Badge>
-                                                {:else}
-                                                        <span class="text-white/60 text-xs uppercase tracking-[0.3em]">Live pot</span>
-                                                {/if}
-                                                <Button size="sm" class="gap-2 bg-white/90 text-slate-900 hover:bg-white">
-                                                        Join pot
-                                                        <ArrowRight class="h-4 w-4" />
-                                                </Button>
-                                        </div>
-                                </div>
-                        </article>
-                {/each}
-        </div>
+	<div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+		<div>
+			<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Now trending</p>
+			<h2 class="text-2xl font-semibold tracking-tight">Community pots</h2>
+			<p class="text-muted-foreground text-sm">Live jackpots filling with the crowd.</p>
+		</div>
+		<Button variant="outline" class="gap-2">
+			View schedule
+			<ArrowRight class="h-4 w-4" />
+		</Button>
+	</div>
+	<div class="grid gap-4 lg:grid-cols-3">
+		{#each pots as pot}
+			<article
+				class={`border-border/60 bg-surface/80 hover:shadow-marketplace-lg relative overflow-hidden rounded-3xl border p-6 transition-all duration-300 hover:-translate-y-1`}
+			>
+				<div
+					class={`absolute inset-0 bg-gradient-to-br ${variantAccent[pot.variant]}`}
+					aria-hidden="true"
+				></div>
+				<div class="relative z-[1] flex flex-col gap-6">
+					<div class="flex items-center justify-between">
+						<div>
+							<p class="text-xs tracking-[0.3em] text-white/70 uppercase">{pot.title}</p>
+							<h3 class="text-3xl font-semibold text-white">{pot.jackpot}</h3>
+						</div>
+						<span
+							class="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/30 bg-black/30 text-white/80"
+						>
+							<Crown class="h-5 w-5" />
+						</span>
+					</div>
+					<div class="flex items-center justify-between gap-3">
+						<div class="flex items-center gap-3 text-white/80">
+							<span
+								class="flex h-10 w-10 items-center justify-center rounded-xl border border-white/30 bg-black/30"
+							>
+								<Timer class="h-4 w-4" />
+							</span>
+							<div>
+								<p class="text-[11px] tracking-[0.3em] text-white/60 uppercase">Ends in</p>
+								<p class="text-sm font-medium">{pot.expiresIn}</p>
+							</div>
+						</div>
+						<div class="flex items-center gap-3 text-white/80">
+							<span
+								class="flex h-10 w-10 items-center justify-center rounded-xl border border-white/30 bg-black/30"
+							>
+								<Users class="h-4 w-4" />
+							</span>
+							<div>
+								<p class="text-[11px] tracking-[0.3em] text-white/60 uppercase">Participants</p>
+								<p class="text-sm font-medium">{pot.participants}</p>
+							</div>
+						</div>
+					</div>
+					<div class="flex items-center justify-between">
+						{#if pot.streak}
+							<Badge
+								variant="secondary"
+								class="border-white/20 bg-black/30 text-[10px] tracking-[0.3em] text-white/80 uppercase"
+							>
+								{pot.streak}
+							</Badge>
+						{:else}
+							<span class="text-xs tracking-[0.3em] text-white/60 uppercase">Live pot</span>
+						{/if}
+						<Button size="sm" class="gap-2 bg-white/90 text-slate-900 hover:bg-white">
+							Join pot
+							<ArrowRight class="h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			</article>
+		{/each}
+	</div>
 </section>

--- a/src/lib/components/home/CommunityRail.svelte
+++ b/src/lib/components/home/CommunityRail.svelte
@@ -27,20 +27,16 @@
 	}
 </script>
 
-<aside class="hidden xl:flex xl:w-[300px] xl:flex-col xl:gap-5 xl:pt-6 xl:pr-4 xl:pl-6">
-	<div class="flex items-center justify-between">
-		<div>
-			<p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">Community</p>
-			<p class="text-foreground text-sm font-semibold">Trading floor chat</p>
-		</div>
-		<span
-			class="bg-primary/15 text-primary flex h-9 w-9 items-center justify-center rounded-xl font-semibold"
-			>💬</span
-		>
-	</div>
+<aside
+	class="hidden h-full w-full flex-col gap-5 rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_20%_20%,rgba(45,212,191,0.16),transparent_55%),radial-gradient(circle_at_80%_40%,rgba(59,130,246,0.18),transparent_60%),rgba(15,23,42,0.78)] p-6 text-white shadow-[0_32px_120px_rgba(15,23,42,0.4)] backdrop-blur-xl xl:flex"
+>
+	<header class="space-y-1">
+		<p class="text-[11px] tracking-[0.35em] text-white/60 uppercase">Community rail</p>
+		<h2 class="text-lg font-semibold text-white">Trading floor chat</h2>
+	</header>
 
 	<div
-		class="border-primary/20 from-primary/15 via-primary/5 rounded-3xl border bg-gradient-to-br to-transparent p-5 shadow-[0_18px_45px_rgba(12,74,110,0.25)] backdrop-blur"
+		class="rounded-3xl border border-white/20 bg-gradient-to-br from-white/10 via-white/5 to-transparent p-5 shadow-[0_18px_45px_rgba(12,74,110,0.25)]"
 	>
 		<div class="flex items-center gap-3">
 			<span
@@ -49,12 +45,12 @@
 				<CloudRain class="h-5 w-5" />
 			</span>
 			<div>
-				<p class="text-xs tracking-[0.3em] text-white/70 uppercase">Rain pot</p>
-				<p class="text-xl font-semibold text-white">{currentPot.total}</p>
+				<p class="text-[11px] tracking-[0.3em] text-white/70 uppercase">Rain pot</p>
+				<p class="text-2xl font-semibold text-white">{currentPot.total}</p>
 			</div>
 		</div>
 		<div
-			class="mt-4 flex items-center justify-between text-[11px] tracking-[0.3em] text-white/70 uppercase"
+			class="mt-4 flex items-center justify-between text-[10px] tracking-[0.3em] text-white/60 uppercase"
 		>
 			<span class="flex items-center gap-2"
 				><Users class="h-3.5 w-3.5" /> {currentPot.contributors} online</span
@@ -63,7 +59,7 @@
 		</div>
 	</div>
 
-	<div class="marketplace-scrollbar flex-1 space-y-3 overflow-y-auto pr-1">
+	<div class="flex flex-1 flex-col gap-3">
 		{#each messages as message}
 			<article
 				class="border-border/40 bg-surface/70 rounded-2xl border px-4 py-3 text-sm shadow-[0_10px_30px_rgba(15,23,42,0.2)]"
@@ -92,13 +88,13 @@
 		{/each}
 	</div>
 	<form
-		class="border-border/40 bg-surface/80 flex items-center gap-2 rounded-2xl border px-4 py-3"
+		class="flex items-center gap-2 rounded-2xl border border-white/15 bg-black/20 px-4 py-3"
 		onsubmit={handleSubmit}
 	>
 		<label class="sr-only" for="community-message">Message</label>
 		<input
 			id="community-message"
-			class="text-foreground placeholder:text-muted-foreground h-10 flex-1 border-0 bg-transparent text-sm focus:outline-none"
+			class="h-10 flex-1 border-0 bg-transparent text-sm text-white placeholder:text-white/50 focus:outline-none"
 			placeholder="Share a drop..."
 			bind:value={input}
 			onkeydown={handleKey}

--- a/src/lib/components/shell/Sidebar.svelte
+++ b/src/lib/components/shell/Sidebar.svelte
@@ -57,84 +57,76 @@
 </script>
 
 <aside
-	class={cn('bg-surface/70 flex h-full w-[240px] flex-none flex-col px-5 pt-8 pb-6', className)}
+	class={cn(
+		'bg-surface/80 border-border/40 flex h-full w-full flex-col rounded-[28px] border p-4 shadow-[0_24px_90px_rgba(15,23,42,0.32)] backdrop-blur-xl',
+		className
+	)}
 >
-	<div class="flex flex-col gap-6">
-		<div>
-			<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Main</p>
-			<nav class="mt-4 space-y-2" aria-label="Primary navigation">
-				{#each navItems as item}
-					<button
-						type="button"
+	<nav class="space-y-2" aria-label="Primary navigation">
+		{#each navItems as item}
+			<button
+				type="button"
+				class={cn(
+					'group flex w-full items-center justify-between rounded-2xl border border-transparent px-2 py-1.5 text-left transition duration-200',
+					'focus-visible:ring-ring/70 focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+					isActiveRoute(item.href)
+						? 'border-primary/60 bg-primary/10 text-foreground shadow-marketplace-sm'
+						: 'text-muted-foreground hover:border-border/50 hover:bg-surface-muted/40 hover:text-foreground'
+				)}
+				onclick={() => handleNavigation(item.href)}
+				aria-current={isActiveRoute(item.href) ? 'page' : undefined}
+			>
+				<span class="flex items-center gap-3">
+					<span
 						class={cn(
-							'group flex w-full items-center justify-between rounded-2xl border border-transparent px-3 py-3 text-left transition duration-200',
-							'focus-visible:ring-ring/70 focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+							'flex h-14 w-14 items-center justify-center rounded-2xl border text-sm font-semibold transition-colors',
 							isActiveRoute(item.href)
-								? 'border-primary/60 bg-surface-accent/30 text-foreground shadow-marketplace-sm'
-								: 'text-muted-foreground hover:border-border/60 hover:bg-surface-muted/40 hover:text-foreground'
+								? 'border-primary/60 bg-primary/20 text-primary'
+								: 'border-border/50 bg-surface-muted/50 text-muted-foreground group-hover:text-foreground'
 						)}
-						onclick={() => handleNavigation(item.href)}
-						aria-current={isActiveRoute(item.href) ? 'page' : undefined}
 					>
-						<span class="flex items-center gap-3">
-							<span
-								class={cn(
-									'flex h-12 w-12 items-center justify-center rounded-xl border',
-									isActiveRoute(item.href)
-										? 'border-primary/60 bg-primary/15 text-primary'
-										: 'border-border/50 bg-surface-muted/40 text-muted-foreground group-hover:text-foreground'
-								)}
-							>
-								<item.icon class="h-4 w-4" />
-							</span>
-							<span>
-								<span class="text-sm leading-tight font-semibold">{item.label}</span>
-								<span class="text-muted-foreground/75 block text-xs">{item.description}</span>
-							</span>
-						</span>
-						{#if isActiveRoute(item.href)}
-							<Badge
-								variant="outline"
-								class="rounded-full px-2 py-0.5 text-[10px] tracking-[0.3em] uppercase"
-								>Active</Badge
-							>
-						{/if}
-					</button>
-				{/each}
-			</nav>
-		</div>
+						<item.icon class="h-4 w-4" />
+					</span>
+					<span class="text-sm font-semibold tracking-tight">{item.label}</span>
+				</span>
+				{#if isActiveRoute(item.href)}
+					<Badge
+						variant="outline"
+						class="rounded-full px-2 py-0.5 text-[9px] tracking-[0.35em] uppercase">Active</Badge
+					>
+				{/if}
+			</button>
+		{/each}
+	</nav>
 
-		<div
-			class="border-border/40 bg-surface/80 rounded-3xl border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.25)]"
-		>
+	<div class="mt-auto space-y-3">
+		<div class="border-border/50 bg-surface/80 rounded-3xl border p-4">
 			{#if isAuthenticated && user}
-				<div class="space-y-4">
-					<div>
+				<div class="space-y-3 text-sm">
+					<div class="flex items-center justify-between">
 						<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Account</p>
-						<p class="mt-1 text-base font-semibold">{user.username}</p>
+						<span class="text-muted-foreground/80 text-xs font-medium">Live</span>
 					</div>
-					<div class="border-border/30 bg-surface-muted/40 space-y-3 rounded-2xl border p-4">
+					<p class="text-base font-semibold">{user.username}</p>
+					<div class="border-border/40 bg-surface-muted/40 grid gap-2 rounded-2xl border p-3">
 						<div>
-							<p class="text-muted-foreground text-[11px] tracking-[0.3em] uppercase">Balance</p>
+							<p class="text-muted-foreground text-[10px] tracking-[0.35em] uppercase">Balance</p>
 							<p class="text-lg font-semibold">${user.balance.toLocaleString()}</p>
 						</div>
 						<div>
-							<p class="text-muted-foreground text-[11px] tracking-[0.3em] uppercase">
-								Total wagered
-							</p>
+							<p class="text-muted-foreground text-[10px] tracking-[0.35em] uppercase">Wagered</p>
 							<p class="text-sm font-medium">${user.totalWagered.toLocaleString()}</p>
 						</div>
-						<Button variant="secondary" class="w-full">Manage funds</Button>
+						<Button variant="secondary" size="sm" class="w-full justify-center">Manage funds</Button
+						>
 					</div>
 				</div>
 			{:else}
-				<div class="space-y-4 text-sm">
-					<div>
-						<p class="text-foreground text-base font-semibold">Sign in to unlock trading</p>
-						<p class="text-muted-foreground text-xs leading-relaxed">
-							Connect your Steam account to deposit, withdraw, and battle with the floor.
-						</p>
-					</div>
+				<div class="space-y-3 text-sm">
+					<p class="text-base leading-tight font-semibold">Sign in to unlock trading</p>
+					<p class="text-muted-foreground text-xs leading-relaxed">
+						Connect Steam to deposit instantly and join live battles.
+					</p>
 					<Button class="w-full gap-2">
 						<LogIn class="h-4 w-4" />
 						Sign in with Steam
@@ -143,19 +135,19 @@
 			{/if}
 		</div>
 
-		<div class="border-border/40 bg-surface/60 rounded-3xl border p-4">
-			<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Support</p>
-			<div class="mt-3 grid gap-2">
+		<div class="border-border/40 bg-surface/70 rounded-3xl border p-3">
+			<p class="text-muted-foreground text-[10px] tracking-[0.35em] uppercase">Support</p>
+			<div class="mt-2 grid gap-2">
 				{#each supportItems as item}
 					<Button
 						as="a"
 						href={item.href}
 						variant="ghost"
 						size="sm"
-						class="text-muted-foreground hover:text-foreground justify-start rounded-full px-3 py-2 text-sm"
+						class="text-muted-foreground hover:text-foreground justify-start gap-3 rounded-2xl px-2 py-1.5 text-sm"
 					>
 						<span
-							class="border-border/40 bg-surface-muted/40 mr-2 flex h-8 w-8 items-center justify-center rounded-full border"
+							class="border-border/40 bg-surface-muted/40 flex h-9 w-9 items-center justify-center rounded-xl border"
 						>
 							<item.icon class="h-4 w-4" />
 						</span>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,24 +20,41 @@
 	<link rel="icon" href={favicon} />
 </svelte:head>
 
-<div class="bg-background text-foreground relative flex min-h-screen flex-col">
-	<Navbar isAuthenticated={data.isAuthenticated} user={data.user} />
+<div
+	class="bg-background text-foreground relative flex min-h-screen flex-col"
+	style="--shell-header-height: 76px"
+>
+	<Navbar
+		isAuthenticated={data.isAuthenticated}
+		user={data.user}
+		class="border-border/60 border-b"
+	/>
 
-	<div class="flex flex-1">
-		<div class="border-border/60 xl:bg-surface/60 hidden xl:flex xl:border-r">
-			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full" />
-		</div>
-
-		<main class="flex-1 overflow-x-hidden">
-			<div
-				class="mx-auto w-full max-w-7xl px-5 pt-8 pb-24 sm:pt-10 sm:pb-16 md:px-8 lg:px-10 xl:px-12"
-			>
-				{@render children?.()}
+	<div class="flex-1 overflow-hidden">
+		<div
+			class="mx-auto flex h-full w-full max-w-[1600px] gap-6 px-4 pt-6 pb-20 sm:px-6 lg:px-8 xl:gap-7"
+		>
+			<div class="hidden xl:flex xl:w-[248px] xl:flex-none">
+				<div
+					class="sticky top-[calc(var(--shell-header-height)+1.5rem)] h-[calc(100vh-var(--shell-header-height)-1.5rem)] w-full"
+				>
+					<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full" />
+				</div>
 			</div>
-		</main>
 
-		<div class="hidden xl:block">
-			<CommunityRail />
+			<main class="marketplace-scrollbar flex-1 overflow-y-auto" aria-label="Primary content">
+				<div class="mx-auto flex w-full max-w-5xl flex-col gap-12 px-1 pt-6 pb-16 sm:px-2">
+					{@render children?.()}
+				</div>
+			</main>
+
+			<div class="hidden xl:flex xl:w-[296px] xl:flex-none">
+				<div
+					class="sticky top-[calc(var(--shell-header-height)+1.5rem)] h-[calc(100vh-var(--shell-header-height)-1.5rem)] w-full"
+				>
+					<CommunityRail />
+				</div>
+			</div>
 		</div>
 	</div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -93,26 +93,27 @@
 		</Alert>
 	{/if}
 
-	<HeroCarousel />
-
-	<section class="space-y-10">
+	<div class="space-y-8">
+		<HeroCarousel />
 		<MarketplaceGrid />
 		<KpiStrip />
-	</section>
+	</div>
 
-	<section class="grid gap-8 xl:grid-cols-[1.4fr,1fr]">
+	<section class="grid gap-8 xl:grid-cols-[1.35fr,1fr]">
 		<CommunityPots />
-		<Card class="border-border/60 bg-surface/70 border">
-			<CardHeader class="gap-1">
-				<Badge variant="outline" class="w-fit">Trading floor</Badge>
-				<CardTitle class="text-xl font-semibold">Flash updates</CardTitle>
-				<CardDescription>Real-time signals from the operations desk.</CardDescription>
+		<Card class="border-border/50 bg-surface/80 border">
+			<CardHeader class="gap-2">
+				<Badge variant="outline" class="w-fit text-[10px] tracking-[0.35em] uppercase"
+					>Desk feed</Badge
+				>
+				<CardTitle class="text-xl font-semibold tracking-tight">Flash updates</CardTitle>
+				<CardDescription class="text-sm">Quick reads from the operations desk.</CardDescription>
 			</CardHeader>
 			<CardContent class="space-y-4">
 				{#each flashUpdates as update}
 					<div class="border-border/60 bg-surface-muted/40 rounded-2xl border p-4">
-						<p class="text-sm font-semibold">{update.title}</p>
-						<p class="text-muted-foreground text-xs">{update.caption}</p>
+						<p class="text-sm font-semibold tracking-tight">{update.title}</p>
+						<p class="text-muted-foreground text-xs leading-relaxed">{update.caption}</p>
 					</div>
 				{/each}
 				<div class="flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary
- restore the desktop shell to a three-column layout with a fixed header and scrolling content column
- compact the sidebar styling and community rail so they stay sticky and align with the refreshed hero plus marketplace stack
- polish the "Now trending" area and flash updates card copy to match the updated homepage structure

## Testing
- pnpm lint *(fails: existing unresolved navigation/a11y lint errors in legacy demo routes)*

------
https://chatgpt.com/codex/tasks/task_e_68da00d408148326aa504a2dc44bbf8e