### PR TITLE
Restore desktop shell grid and compact sidebar

### DIFF
--- a/src/lib/components/shell/Sidebar.svelte
+++ b/src/lib/components/shell/Sidebar.svelte
@@ -13,7 +13,7 @@
 		MessageSquare,
 		Shield,
 		LifeBuoy,
-		ArrowDownUp,
+		ChevronDown,
 		Briefcase
 	} from 'lucide-svelte';
 	import { Button } from '$lib/components/ui';
@@ -28,12 +28,14 @@
 			totalWagered: number;
 		} | null;
 		class?: string;
+		density?: 'default' | 'compact';
 	};
 
 	const props = $props<SidebarProps>();
 	const inboundUser = $derived(() => props.user ?? null);
 	const inboundAuthenticated = $derived(() => props.isAuthenticated ?? false);
 	const className = $derived(() => props.class ?? '');
+	const density = $derived(() => props.density ?? 'default');
 
 	const pageStore = page;
 	const currentPage = $derived(pageStore);
@@ -71,7 +73,6 @@
 	const activeUser = $derived(() => {
 		if (!previewSignedIn) return null;
 		const user = inboundUser ?? fallbackUser;
-		// Ensure balance is always defined
 		return {
 			...user,
 			balance: user?.balance ?? 0
@@ -87,6 +88,18 @@
 		previewSignedIn = !previewSignedIn;
 	};
 
+	let showBreakdown = $state(false);
+
+	const toggleBreakdown = () => {
+		showBreakdown = !showBreakdown;
+	};
+
+	$effect(() => {
+		if (!activeUser) {
+			showBreakdown = false;
+		}
+	});
+
 	const isActiveRoute = (href: string) => currentPath === href;
 
 	const buildHref = (path: string) => (base ? `${base}${path}` : path);
@@ -100,7 +113,8 @@
 
 <aside
 	class={cn(
-		'bg-surface/80 border-border/40 flex h-full w-full flex-col gap-6 rounded-[32px] border px-6 py-6 shadow-[0_32px_120px_rgba(15,23,42,0.36)] backdrop-blur-xl',
+		'bg-surface/80 border-border/40 flex h-full w-full flex-col rounded-[32px] border shadow-[0_32px_120px_rgba(15,23,42,0.36)] backdrop-blur-xl',
+		density === 'compact' ? 'gap-4 px-4 py-3' : 'gap-6 px-6 py-6',
 		className
 	)}
 >
@@ -116,75 +130,6 @@
 			<p class="text-muted-foreground text-[11px] tracking-[0.35em] uppercase">CS2 Marketplace</p>
 		</div>
 	</a>
-
-	<div class="border-border/40 bg-surface-muted/30 rounded-3xl border p-4">
-		{#if activeUser}
-			<div class="space-y-4">
-				<div class="flex items-center justify-between">
-					<div>
-						<p class="text-muted-foreground text-[11px] tracking-[0.35em] uppercase">Balance</p>
-						<p class="text-2xl font-semibold">${(activeUser.balance ?? 0).toLocaleString()}</p>
-					</div>
-					<Button
-						variant="ghost"
-						size="sm"
-						onclick={togglePreviewState}
-						class="text-muted-foreground hover:text-foreground h-9 rounded-xl px-3 text-xs tracking-[0.3em] uppercase"
-					>
-						Hide
-					</Button>
-				</div>
-				<div class="grid gap-2 text-sm">
-					{#each vaultSummary as item (item.label)}
-						<div
-							class="border-border/40 bg-surface/70 flex items-center justify-between rounded-2xl border px-3 py-2"
-						>
-							<span class="text-muted-foreground text-xs tracking-[0.3em] uppercase"
-								>{item.label}</span
-							>
-							<span class="font-medium">{item.value}</span>
-						</div>
-					{/each}
-				</div>
-				<div class="grid grid-cols-2 gap-3">
-					<Button variant="secondary" class="h-12 rounded-2xl text-sm font-semibold">Deposit</Button
-					>
-					<Button variant="ghost" class="h-12 rounded-2xl text-sm font-semibold">Withdraw</Button>
-				</div>
-			</div>
-		{:else}
-			<div class="space-y-3">
-				<div class="flex items-start justify-between gap-4">
-					<div class="space-y-1.5">
-						<p class="text-base leading-snug font-semibold">Sign in with Steam</p>
-						<p class="text-muted-foreground text-sm leading-relaxed">
-							Connect to deposit instantly, track balance, and join premium drops.
-						</p>
-					</div>
-					<Button
-						variant="ghost"
-						size="sm"
-						onclick={togglePreviewState}
-						class="text-muted-foreground hover:text-foreground h-9 rounded-xl px-3 text-xs tracking-[0.3em] uppercase"
-					>
-						Preview
-					</Button>
-				</div>
-				<form method="POST" action="/api/auth/steam/login" class="w-full">
-					<AuthButton
-						class="bg-primary text-primary-foreground shadow-marketplace-md w-full justify-center gap-2"
-					/>
-				</form>
-				<Button
-					variant="ghost"
-					class="text-muted-foreground hover:text-foreground h-12 w-full gap-2 rounded-2xl text-sm"
-				>
-					<LogIn class="h-4 w-4" />
-					Explore as guest
-				</Button>
-			</div>
-		{/if}
-	</div>
 
 	<nav class="space-y-2" aria-label="Primary navigation">
 		{#each navItems as item (item.href)}
@@ -218,12 +163,101 @@
 		{/each}
 	</nav>
 
+	<section class="border-border/40 bg-surface-muted/30 rounded-3xl border p-4">
+		{#if activeUser}
+			<div class="space-y-3">
+				<div class="flex items-start justify-between gap-4">
+					<div class="space-y-1">
+						<p class="text-muted-foreground text-[11px] tracking-[0.35em] uppercase">
+							Total balance
+						</p>
+						<p class="text-3xl leading-tight font-semibold tracking-tight">
+							${(activeUser.balance ?? 0).toLocaleString()}
+						</p>
+						<p class="text-muted-foreground text-xs">
+							Lifetime wagered ${activeUser.totalWagered.toLocaleString()}
+						</p>
+					</div>
+					<Button
+						variant="ghost"
+						size="sm"
+						onclick={togglePreviewState}
+						class="text-muted-foreground hover:text-foreground h-9 rounded-xl px-3 text-[11px] tracking-[0.3em] uppercase"
+					>
+						Hide
+					</Button>
+				</div>
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={toggleBreakdown}
+					class="text-muted-foreground hover:text-foreground flex w-full items-center justify-between rounded-2xl px-3 py-2 text-[11px] tracking-[0.3em] uppercase"
+				>
+					Balance breakdown
+					<ChevronDown
+						class={cn(
+							'h-4 w-4 transition-transform duration-200',
+							showBreakdown ? 'rotate-180' : ''
+						)}
+					/>
+				</Button>
+				{#if showBreakdown}
+					<div class="grid gap-2 text-sm">
+						{#each vaultSummary as item (item.label)}
+							<div
+								class="border-border/40 bg-surface/70 flex items-center justify-between rounded-2xl border px-3 py-2"
+							>
+								<span class="text-muted-foreground text-xs tracking-[0.3em] uppercase"
+									>{item.label}</span
+								>
+								<span class="font-medium">{item.value}</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+				<div class="grid grid-cols-2 gap-3">
+					<Button variant="secondary" class="h-12 rounded-2xl text-sm font-semibold">Deposit</Button
+					>
+					<Button variant="ghost" class="h-12 rounded-2xl text-sm font-semibold">Withdraw</Button>
+				</div>
+			</div>
+		{:else}
+			<div class="space-y-3">
+				<div class="space-y-1">
+					<p class="text-base leading-snug font-semibold">Sign in with Steam</p>
+					<p class="text-muted-foreground text-sm leading-relaxed">
+						Connect to deposit instantly, track balance, and join premium drops.
+					</p>
+				</div>
+				<form method="POST" action="/api/auth/steam/login" class="w-full">
+					<AuthButton
+						class="bg-primary text-primary-foreground shadow-marketplace-md w-full justify-center gap-2"
+					/>
+				</form>
+				<div class="flex items-center justify-between gap-3">
+					<Button
+						variant="ghost"
+						size="sm"
+						onclick={togglePreviewState}
+						class="text-muted-foreground hover:text-foreground h-9 rounded-xl px-3 text-[11px] tracking-[0.3em] uppercase"
+					>
+						Preview
+					</Button>
+					<Button
+						variant="ghost"
+						class="text-muted-foreground hover:text-foreground h-12 flex-1 gap-2 rounded-2xl text-sm"
+					>
+						<LogIn class="h-4 w-4" />
+						Explore as guest
+					</Button>
+				</div>
+			</div>
+		{/if}
+	</section>
+
 	<div class="mt-auto space-y-4">
 		<div class="border-border/40 bg-surface/70 rounded-3xl border p-4">
-			<div class="text-muted-foreground mb-3 flex items-center justify-between text-xs">
-				<span class="tracking-[0.3em] uppercase">Live support</span>
-				<ArrowDownUp class="h-4 w-4" />
-			</div>
+			<p class="text-muted-foreground mb-3 text-[11px] tracking-[0.35em] uppercase">Support</p>
 			<div class="grid gap-2">
 				{#each supportItems as item (item.href)}
 					<Button

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,45 +32,41 @@
 
 <div class="bg-background text-foreground">
 	<div
-		class="mx-auto grid min-h-[100dvh] w-full max-w-[1920px] grid-cols-1 gap-4 px-4 pt-4 pb-[92px] sm:px-6 lg:px-8 xl:grid-cols-[260px,minmax(0,1fr),320px] xl:gap-6 xl:px-10"
+		class="mx-auto grid min-h-[100dvh] w-full max-w-[1920px] grid-cols-1 gap-6 px-4 pt-4 pb-[92px] sm:px-6 lg:px-8 xl:grid-cols-[260px,minmax(0,1fr),320px] xl:items-start xl:gap-8 xl:px-10 xl:pt-6 xl:pb-6"
 	>
-		<aside class="hidden xl:block">
-			<div class="sticky top-4 flex h-[calc(100dvh-2rem)] flex-col">
-				<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="flex-1" />
-			</div>
+		<aside class="hidden xl:sticky xl:top-0 xl:flex xl:min-h-[100dvh] xl:flex-col">
+			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="flex-1" />
 		</aside>
 
 		<div
-			class="xl:bg-surface/70 relative flex min-h-[100dvh] flex-col rounded-none xl:col-start-2 xl:rounded-[32px] xl:border xl:border-white/10 xl:shadow-[0_32px_120px_rgba(15,23,42,0.35)] xl:backdrop-blur"
+			class="xl:bg-surface/70 relative flex min-h-[100dvh] flex-col rounded-none xl:col-start-2 xl:min-h-0 xl:overflow-hidden xl:rounded-[32px] xl:border xl:border-white/10 xl:shadow-[0_32px_120px_rgba(15,23,42,0.35)] xl:backdrop-blur"
 		>
 			<div class="sticky top-0 z-30 xl:rounded-t-[32px]">
 				<ShellHeader {promoTicker} isAuthenticated={data.isAuthenticated} user={data.user} />
 			</div>
 			<main
-				class="marketplace-scrollbar flex-1 overflow-y-auto px-1 pt-6 pb-20 sm:px-3 md:px-4 xl:px-8"
+				class="marketplace-scrollbar flex-1 overflow-y-auto px-1 pt-6 pb-24 sm:px-3 md:px-4 xl:px-8 xl:pb-12"
 				aria-label="Primary content"
 			>
-				<div class="mx-auto flex w-full max-w-[1140px] flex-col gap-12 pb-6">
+				<div class="mx-auto flex w-full max-w-none flex-col gap-10 pb-10">
 					{@render children?.()}
 				</div>
 			</main>
 		</div>
 
-		<aside class="hidden xl:block">
-			<div class="sticky top-4 flex h-[calc(100dvh-2rem)] flex-col">
-				<CommunityRail />
-			</div>
+		<aside class="hidden xl:sticky xl:top-0 xl:flex xl:min-h-[100dvh] xl:flex-col">
+			<CommunityRail />
 		</aside>
 	</div>
 
 	<BottomNav
 		isAuthenticated={data.isAuthenticated}
-		class="fixed inset-x-0 bottom-0 z-40 border-t pb-[env(safe-area-inset-bottom)] xl:hidden"
+		class="fixed inset-x-0 bottom-0 z-40 border-t pb-[env(safe-area-inset-bottom)] lg:hidden"
 	/>
 
 	<button
 		type="button"
-		class="bg-primary text-primary-foreground shadow-marketplace-lg fixed right-4 bottom-[92px] z-40 flex items-center gap-3 rounded-full px-4 py-3 text-sm font-medium md:right-6 md:bottom-[96px] xl:hidden"
+		class="bg-primary text-primary-foreground shadow-marketplace-lg fixed right-4 bottom-[88px] z-40 flex items-center gap-3 rounded-full px-5 py-3 text-sm font-semibold sm:right-6 sm:bottom-[92px] lg:hidden"
 		onclick={handleChatToggle}
 		aria-pressed={chatOpen}
 	>
@@ -89,9 +85,14 @@
 			onclick={handleSidebarClose}
 		></div>
 		<div
-			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[320px] max-w-[88vw] overflow-y-auto px-6 pt-6 pb-8 backdrop-blur-xl xl:hidden"
+			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[320px] max-w-[88vw] overflow-y-auto px-4 pt-4 pb-8 backdrop-blur-xl xl:hidden"
 		>
-			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full" />
+			<Sidebar
+				isAuthenticated={data.isAuthenticated}
+				user={data.user}
+				class="h-full"
+				density="compact"
+			/>
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- rebuild the root layout shell with an explicit three-column grid, sticky sidebar/rail columns, and a dedicated center scroll surface while widening the content stack and updating mobile-only elements
- trim the sidebar to show navigation first, add a compact balance card with a breakdown toggle, and refresh support links while allowing a compact density for the slide-out drawer

## Testing
- pnpm check *(fails: existing missing paraglide/supabase modules and legacy Svelte warnings)*
- pnpm lint *(fails: repository-preexisting Prettier formatting issues in ShellHeader.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68da7437ca8c83269145e196f8bc7bac