### PR TITLE
refactor: migrate shell ui to svelte 5 runes

### DIFF
--- a/src/lib/components/shell/BottomNav.svelte
+++ b/src/lib/components/shell/BottomNav.svelte
@@ -5,18 +5,10 @@
 	import { Home, Package, Swords, ArrowUpRight, Briefcase } from 'lucide-svelte';
 	import { cn } from '$lib/utils';
 
-	type BottomNavProps = {
+	const { isAuthenticated = false, class: className = '' } = $props<{
 		isAuthenticated?: boolean;
 		class?: string;
-	};
-
-	const props = $props<BottomNavProps>();
-	const isAuthenticated = $derived(() => props.isAuthenticated ?? false);
-	const className = $derived(() => props.class ?? '');
-
-	const pageStore = page;
-	const currentPage = $derived(pageStore);
-	const currentPath = $derived(() => currentPage.url.pathname);
+	}>();
 
 	const items = [
 		{ href: '/', label: 'Home', icon: Home },
@@ -26,7 +18,7 @@
 		{ href: '/inventory', label: 'Inventory', icon: Briefcase }
 	] as const;
 
-	const isActiveRoute = (href: string) => currentPath === href;
+	const isActiveRoute = (href: string) => $page.url.pathname === href;
 	const buildHref = (path: string) => (base ? `${base}${path}` : path);
 	const handleNavigation = (href: string) => {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve

--- a/src/lib/components/shell/ChatDrawer.svelte
+++ b/src/lib/components/shell/ChatDrawer.svelte
@@ -11,9 +11,6 @@
 	import { X, Send, MessageCircle, CloudRain, Users } from 'lucide-svelte';
 	import { Button, Sheet, SheetContent } from '$lib/components/ui';
 
-	const uiState = $derived(uiStore);
-	const chatOpen = $derived(() => uiState.chatOpen);
-
 	let messages = $state<CommunityMessage[]>(get(communityMessages));
 	let currentPot = $state<RainPot>(get(rainPot));
 	let input = $state('');
@@ -57,7 +54,7 @@
 	};
 </script>
 
-<Sheet open={chatOpen} onOpenChange={(open) => (!open ? closeChat() : undefined)}>
+<Sheet open={$uiStore.chatOpen} onOpenChange={(open) => (!open ? closeChat() : undefined)}>
 	<SheetContent
 		side="bottom"
 		class="border-border/40 bg-surface/95 max-h-[75vh] w-full translate-y-0 rounded-t-[32px] border px-0 pt-4 pb-[env(safe-area-inset-bottom)] shadow-[0_-40px_120px_rgba(15,23,42,0.65)] backdrop-blur-xl md:max-w-xl"
@@ -154,7 +151,7 @@
 					rows={1}
 					placeholder="Drop a message…"
 					class="marketplace-scrollbar max-h-24 flex-1 resize-none border-0 bg-transparent px-2 py-1 text-sm focus:outline-none"
-				/>
+				></textarea>
 				<Button size="icon" class="h-11 w-11 rounded-2xl" type="submit">
 					<Send class="h-4 w-4" />
 					<span class="sr-only">Send message</span>

--- a/src/lib/components/shell/ShellHeader.svelte
+++ b/src/lib/components/shell/ShellHeader.svelte
@@ -14,7 +14,12 @@
 	import { Bell, ChevronDown, Globe, Menu, Megaphone, Search } from 'lucide-svelte';
 	import { createEventDispatcher } from 'svelte';
 
-	type ShellHeaderProps = {
+	const {
+		promoTicker,
+		isAuthenticated = false,
+		user = null,
+		class: className = ''
+	} = $props<{
 		promoTicker: { id: string; label: string; meta: string }[];
 		isAuthenticated?: boolean;
 		user?: {
@@ -23,22 +28,11 @@
 			totalWagered: number;
 		} | null;
 		class?: string;
-	};
+	}>();
 
-	const props = $props<ShellHeaderProps>();
-	const promoTicker = $derived(() => props.promoTicker);
-	const isAuthenticated = $derived(() => props.isAuthenticated ?? false);
-	const user = $derived(() => props.user ?? null);
-	const className = $derived(() => props.class ?? '');
-
-	const uiState = $derived(uiStore);
-	const sidebarOpen = $derived(() => uiState.sidebarOpen);
-
-	const pageStore = page;
-	const currentPage = $derived(pageStore);
 	const pageTitle = $derived(() => {
-		const pathname = currentPage.url.pathname;
-		if (pathname === '/' || pathname === '') return 'Home';
+		const pathname = $page.url.pathname;
+		if (pathname === '/') return 'Home';
 		const segments = pathname.split('/').filter(Boolean);
 		if (!segments.length) return 'Home';
 		const key = segments[0];
@@ -73,7 +67,7 @@
 				type="button"
 				class="border-border/70 bg-surface-muted/60 text-muted-foreground focus-visible:ring-ring/70 flex h-11 w-11 items-center justify-center rounded-2xl border transition focus-visible:ring-2 focus-visible:outline-none"
 				onclick={toggleSidebar}
-				aria-expanded={sidebarOpen}
+				aria-expanded={$uiStore.sidebarOpen}
 				aria-label="Open navigation"
 			>
 				<Menu class="h-5 w-5" />
@@ -166,7 +160,11 @@
 						class="border-border/60 bg-surface-muted/60 hover:border-primary/50 hover:bg-surface-muted/80 focus-visible:ring-ring/70 focus-visible:ring-offset-background flex items-center gap-3 rounded-2xl border px-2 py-1.5 transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 					>
 						{#if user.avatar}
-							<img src={user.avatar} alt={user.username || 'User'} class="h-9 w-9 rounded-xl object-cover" />
+							<img
+								src={user.avatar}
+								alt={user.username || 'User'}
+								class="h-9 w-9 rounded-xl object-cover"
+							/>
 						{:else}
 							<div
 								class="border-border/60 bg-surface-muted/70 text-muted-foreground flex h-9 w-9 items-center justify-center rounded-xl border font-semibold"

--- a/src/lib/components/ui/alert.svelte
+++ b/src/lib/components/ui/alert.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 
 	type AlertVariant = 'default' | 'success' | 'info' | 'warning' | 'destructive';
 
-	let { variant = 'default' as AlertVariant, class: className = '' } = $props();
+	const {
+		variant = 'default',
+		class: className = '',
+		children
+	} = $props<{
+		variant?: AlertVariant;
+		class?: string;
+		children?: Snippet;
+	}>();
 
 	const variants: Record<AlertVariant, string> = {
 		default: 'border border-border/70 bg-surface-muted/60 text-foreground',
@@ -22,5 +31,5 @@
 		className
 	)}
 >
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/badge.svelte
+++ b/src/lib/components/ui/badge.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 
 	type BadgeVariant = 'default' | 'outline' | 'success' | 'warning' | 'info' | 'destructive';
-	let { variant = 'default' as BadgeVariant, class: className = '' } = $props();
+	const {
+		variant = 'default',
+		class: className = '',
+		children
+	} = $props<{
+		variant?: BadgeVariant;
+		class?: string;
+		children?: Snippet;
+	}>();
 
 	const variants: Record<BadgeVariant, string> = {
 		default: 'bg-primary/15 text-primary border border-primary/35',
@@ -21,5 +30,5 @@
 		className
 	)}
 >
-	<slot />
+	{@render children?.()}
 </span>

--- a/src/lib/components/ui/button.svelte
+++ b/src/lib/components/ui/button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 
 	type ButtonVariant = 'default' | 'secondary' | 'outline' | 'ghost' | 'destructive';
 	type ButtonSize = 'sm' | 'md' | 'lg' | 'icon';
@@ -11,15 +12,17 @@
 		size?: ButtonSize;
 		class?: string;
 		disabled?: boolean;
+		children?: Snippet;
 	} & Record<string, unknown>;
 
-	let {
+	const {
 		as: asProp = undefined,
 		type = 'button',
-		variant = 'default' as ButtonVariant,
-		size = 'md' as ButtonSize,
+		variant = 'default',
+		size = 'md',
 		class: className = '',
 		disabled = false,
+		children,
 		...restProps
 	}: ButtonProps = $props();
 
@@ -56,5 +59,5 @@
 	{disabled}
 	{...restProps}
 >
-	<slot />
+	{@render children?.()}
 </svelte:element>

--- a/src/lib/components/ui/card-content.svelte
+++ b/src/lib/components/ui/card-content.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	let { class: className = '' } = $props();
+	import type { Snippet } from 'svelte';
+
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <div class={cn('px-6 py-5', className)}>
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/card-description.svelte
+++ b/src/lib/components/ui/card-description.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	let { class: className = '' } = $props();
+	import type { Snippet } from 'svelte';
+
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <p class={cn('text-muted-foreground text-sm', className)}>
-	<slot />
+	{@render children?.()}
 </p>

--- a/src/lib/components/ui/card-footer.svelte
+++ b/src/lib/components/ui/card-footer.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	let { class: className = '' } = $props();
+	import type { Snippet } from 'svelte';
+
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <div
@@ -9,5 +14,5 @@
 		className
 	)}
 >
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/card-header.svelte
+++ b/src/lib/components/ui/card-header.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	let { class: className = '' } = $props();
+	import type { Snippet } from 'svelte';
+
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <div class={cn('border-border/60 flex flex-col gap-1.5 border-b px-6 py-5', className)}>
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/card-title.svelte
+++ b/src/lib/components/ui/card-title.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	let { class: className = '' } = $props();
+	import type { Snippet } from 'svelte';
+
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <h3 class={cn('text-card-foreground text-lg font-semibold', className)}>
-	<slot />
+	{@render children?.()}
 </h3>

--- a/src/lib/components/ui/card.svelte
+++ b/src/lib/components/ui/card.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 
-	let { class: className = '' } = $props();
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <div
@@ -10,5 +14,5 @@
 		className
 	)}
 >
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/dropdown-menu/context.ts
+++ b/src/lib/components/ui/dropdown-menu/context.ts
@@ -1,8 +1,7 @@
 import { getContext, setContext } from 'svelte';
-import type { Writable } from 'svelte/store';
 
 export interface DropdownContext {
-	open: Writable<boolean>;
+	open: () => boolean;
 	setOpen: (open: boolean) => void;
 }
 

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -2,16 +2,22 @@
 	import { onMount } from 'svelte';
 	import { cn } from '$lib/utils';
 	import { useDropdownContext } from './context';
-	import { derived } from 'svelte/store';
+	import type { Snippet } from 'svelte';
 
-	let {
-		align = 'end' as 'start' | 'end',
+	const {
+		align = 'end',
 		class: className = '',
-		labelledby
-	}: { align?: 'start' | 'end'; class?: string; labelledby?: string } = $props();
+		labelledby,
+		children
+	} = $props<{
+		align?: 'start' | 'end';
+		class?: string;
+		labelledby?: string;
+		children?: Snippet<{ setOpen: (open: boolean) => void }>;
+	}>();
 
 	const { open, setOpen } = useDropdownContext();
-	const visible = derived(open, ($open) => $open);
+	const visible = $derived(open());
 	let container: HTMLDivElement | null = null;
 
 	onMount(() => {
@@ -24,11 +30,16 @@
 		window.addEventListener('click', handleClick);
 		return () => window.removeEventListener('click', handleClick);
 	});
+
+	const handleContainerClick = (event: MouseEvent) => {
+		event.stopPropagation();
+	};
 </script>
 
-{#if $visible}
+{#if visible}
 	<div
 		role="menu"
+		tabindex="-1"
 		aria-labelledby={labelledby}
 		class={cn(
 			'border-border/60 bg-popover shadow-marketplace-lg animate-slide-up absolute z-50 mt-2 min-w-[14rem] overflow-hidden rounded-lg border p-2 text-sm',
@@ -36,8 +47,8 @@
 			className
 		)}
 		bind:this={container}
-		on:click|stopPropagation
+		onclick={handleContainerClick}
 	>
-		<slot {setOpen} />
+		{@render children?.({ setOpen })}
 	</div>
 {/if}

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import { useDropdownContext } from './context';
+	import type { Snippet } from 'svelte';
 
-	let {
+	const {
 		inset = false,
 		class: className = '',
-		onSelect
-	}: { inset?: boolean; class?: string; onSelect?: (event: MouseEvent) => void } = $props();
+		onSelect,
+		children
+	} = $props<{
+		inset?: boolean;
+		class?: string;
+		onSelect?: (event: MouseEvent) => void;
+		children?: Snippet;
+	}>();
 
 	const { setOpen } = useDropdownContext();
+
+	const handleClick = (event: MouseEvent) => {
+		onSelect?.(event);
+		setOpen(false);
+	};
 </script>
 
 <button
@@ -19,10 +31,7 @@
 		inset && 'pl-9',
 		className
 	)}
-	onclick={(event) => {
-		onSelect?.(event);
-		setOpen(false);
-	}}
+	onclick={handleClick}
 >
-	<slot />
+	{@render children?.()}
 </button>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-trigger.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-trigger.svelte
@@ -1,17 +1,27 @@
 <script lang="ts">
 	import { useDropdownContext } from './context';
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 
-	let { class: className = '' } = $props();
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 	const { open, setOpen } = useDropdownContext();
+	const isOpen = $derived(open());
+
+	const handleClick = (event: MouseEvent) => {
+		event.stopPropagation();
+		setOpen(!isOpen);
+	};
 </script>
 
 <button
 	type="button"
 	aria-haspopup="menu"
-	aria-expanded={$open}
+	aria-expanded={isOpen}
 	class={cn('inline-flex items-center justify-center', className)}
-	on:click|stopPropagation={() => setOpen(!$open)}
+	onclick={handleClick}
 >
-	<slot />
+	{@render children?.()}
 </button>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
@@ -1,28 +1,34 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import { writable } from 'svelte/store';
 	import { initDropdownContext } from './context';
+	import type { Snippet } from 'svelte';
 
-	let {
+	const {
 		open = false,
 		class: className = '',
-		onOpenChange
-	}: { open?: boolean; class?: string; onOpenChange?: (open: boolean) => void } = $props();
+		onOpenChange,
+		children
+	} = $props<{
+		open?: boolean;
+		class?: string;
+		onOpenChange?: (open: boolean) => void;
+		children?: Snippet;
+	}>();
 
-	const internal = writable(open);
+	let isOpen = $state(open);
 
 	$effect(() => {
-		internal.set(open);
+		isOpen = open;
 	});
 
-	function setOpen(next: boolean) {
-		internal.set(next);
+	const setOpen = (next: boolean) => {
+		isOpen = next;
 		onOpenChange?.(next);
-	}
+	};
 
-	initDropdownContext({ open: internal, setOpen });
+	initDropdownContext({ open: () => isOpen, setOpen });
 </script>
 
 <div class={cn('relative inline-block text-left', className)}>
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/sheet/context.ts
+++ b/src/lib/components/ui/sheet/context.ts
@@ -1,8 +1,7 @@
 import { getContext, setContext } from 'svelte';
-import type { Writable } from 'svelte/store';
 
 export interface SheetContext {
-	open: Writable<boolean>;
+	open: () => boolean;
 	close: () => void;
 	openSheet: () => void;
 }

--- a/src/lib/components/ui/sheet/sheet-close.svelte
+++ b/src/lib/components/ui/sheet/sheet-close.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { useSheetContext } from './context';
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 
-	let { class: className = '' } = $props();
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 	const { close } = useSheetContext();
 </script>
 
@@ -11,5 +15,5 @@
 	class={cn('inline-flex items-center justify-center', className)}
 	onclick={() => close()}
 >
-	<slot />
+	{@render children?.()}
 </button>

--- a/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,18 +1,24 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import { useSheetContext } from './context';
-	import { derived } from 'svelte/store';
+	import type { Snippet } from 'svelte';
 
 	type SheetSide = 'left' | 'right' | 'bottom';
 
-	let {
-		side = 'right' as SheetSide,
+	const {
+		side = 'right',
 		class: className = '',
-		labelledby
-	}: { side?: SheetSide; class?: string; labelledby?: string } = $props();
+		labelledby,
+		children
+	} = $props<{
+		side?: SheetSide;
+		class?: string;
+		labelledby?: string;
+		children?: Snippet;
+	}>();
 
 	const { open, close } = useSheetContext();
-	const visible = derived(open, ($open) => $open);
+	const visible = $derived(open());
 
 	const sideClasses: Record<SheetSide, string> = {
 		left: 'inset-y-0 left-0 w-full max-w-md',
@@ -21,9 +27,14 @@
 	};
 </script>
 
-{#if $visible}
+{#if visible}
 	<div class="fixed inset-0 z-40 flex" role="dialog" aria-modal="true" aria-labelledby={labelledby}>
-		<div class="absolute inset-0 bg-black/60 backdrop-blur-sm" onclick={() => close()}></div>
+		<button
+			type="button"
+			class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+			aria-label="Close sheet overlay"
+			onclick={() => close()}
+		></button>
 		<div
 			class={cn(
 				'bg-surface text-surface-foreground shadow-marketplace-lg border-border/60 relative z-10 border',
@@ -32,7 +43,7 @@
 				className
 			)}
 		>
-			<slot />
+			{@render children?.()}
 		</div>
 	</div>
 {/if}

--- a/src/lib/components/ui/sheet/sheet-footer.svelte
+++ b/src/lib/components/ui/sheet/sheet-footer.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	let { class: className = '' } = $props();
+	import type { Snippet } from 'svelte';
+
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <footer
 	class={cn('border-border/60 flex items-center justify-end gap-3 border-t px-6 py-4', className)}
 >
-	<slot />
+	{@render children?.()}
 </footer>

--- a/src/lib/components/ui/sheet/sheet-header.svelte
+++ b/src/lib/components/ui/sheet/sheet-header.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	let { class: className = '' } = $props();
+	import type { Snippet } from 'svelte';
+
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 </script>
 
 <header
 	class={cn('border-border/60 flex items-center justify-between border-b px-6 py-4', className)}
 >
-	<slot />
+	{@render children?.()}
 </header>

--- a/src/lib/components/ui/sheet/sheet-trigger.svelte
+++ b/src/lib/components/ui/sheet/sheet-trigger.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { useSheetContext } from './context';
 	import { cn } from '$lib/utils';
+	import type { Snippet } from 'svelte';
 
-	let { class: className = '' } = $props();
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 	const { openSheet } = useSheetContext();
 </script>
 
@@ -11,5 +15,5 @@
 	class={cn('inline-flex items-center justify-center', className)}
 	onclick={() => openSheet()}
 >
-	<slot />
+	{@render children?.()}
 </button>

--- a/src/lib/components/ui/sheet/sheet.svelte
+++ b/src/lib/components/ui/sheet/sheet.svelte
@@ -1,32 +1,38 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import { writable } from 'svelte/store';
 	import { initSheetContext } from './context';
+	import type { Snippet } from 'svelte';
 
-	let {
+	const {
 		open = false,
 		class: className = '',
-		onOpenChange
-	}: { open?: boolean; class?: string; onOpenChange?: (open: boolean) => void } = $props();
+		onOpenChange,
+		children
+	} = $props<{
+		open?: boolean;
+		class?: string;
+		onOpenChange?: (open: boolean) => void;
+		children?: Snippet;
+	}>();
 
-	const internal = writable(open);
+	let isOpen = $state(open);
 
 	$effect(() => {
-		internal.set(open);
+		isOpen = open;
 	});
 
-	function setOpen(next: boolean) {
-		internal.set(next);
+	const setOpen = (next: boolean) => {
+		isOpen = next;
 		onOpenChange?.(next);
-	}
+	};
 
 	initSheetContext({
-		open: internal,
+		open: () => isOpen,
 		close: () => setOpen(false),
 		openSheet: () => setOpen(true)
 	});
 </script>
 
 <div class={cn(className)}>
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/tabs/context.ts
+++ b/src/lib/components/ui/tabs/context.ts
@@ -1,8 +1,7 @@
 import { getContext, setContext } from 'svelte';
-import type { Writable } from 'svelte/store';
 
 export interface TabsContext {
-	value: Writable<string>;
+	value: () => string;
 	setValue: (value: string) => void;
 }
 

--- a/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/src/lib/components/ui/tabs/tabs-content.svelte
@@ -1,21 +1,29 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import { useTabsContext } from './context';
-	import { derived } from 'svelte/store';
+	import type { Snippet } from 'svelte';
 
-	let { value, class: className = '' } = $props<{ value: string; class?: string }>();
+	const {
+		value,
+		class: className = '',
+		children
+	} = $props<{
+		value: string;
+		class?: string;
+		children?: Snippet;
+	}>();
 
-	const { value: store } = useTabsContext();
-	const selected = derived(store, ($value) => $value === value);
+	const { value: getValue } = useTabsContext();
+	const selected = $derived(getValue() === value);
 </script>
 
 <div
 	role="tabpanel"
 	class={cn(
 		'border-border/60 bg-surface/40 shadow-marketplace-sm rounded-lg border p-6',
-		!$selected && 'hidden',
+		!selected && 'hidden',
 		className
 	)}
 >
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import { useTabsContext } from './context';
-	import { derived } from 'svelte/store';
+	import type { Snippet } from 'svelte';
 
-	let { class: className = '' } = $props();
+	const { class: className = '', children } = $props<{
+		class?: string;
+		children?: Snippet;
+	}>();
 
 	const { value } = useTabsContext();
-	const active = derived(value, ($value) => $value);
+	const active = $derived(value());
 </script>
 
 <div
@@ -16,7 +19,7 @@
 		'border-border/70 bg-surface-muted/40 inline-flex items-center gap-1 rounded-md border p-1 text-sm',
 		className
 	)}
-	data-active={$active}
+	data-active={active}
 >
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -1,34 +1,35 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import { useTabsContext } from './context';
-	import { derived } from 'svelte/store';
+	import type { Snippet } from 'svelte';
 
-	let {
-		value,
+	const {
+		value: tabValue,
 		class: className = '',
-		disabled = false
-	} = $props<{ value: string; class?: string; disabled?: boolean }>();
+		disabled = false,
+		children
+	} = $props<{ value: string; class?: string; disabled?: boolean; children?: Snippet }>();
 
-	const { value: store, setValue } = useTabsContext();
-	const selected = derived(store, ($value) => $value === value);
+	const { value, setValue } = useTabsContext();
+	const selected = $derived(value() === tabValue);
 
-	function handleClick(event: MouseEvent) {
+	const handleClick = (event: MouseEvent) => {
 		if (disabled) {
 			event.preventDefault();
 			return;
 		}
-		setValue(value);
-	}
+		setValue(tabValue);
+	};
 </script>
 
 <button
 	type="button"
 	role="tab"
-	aria-selected={$selected}
-	tabindex={$selected ? 0 : -1}
+	aria-selected={selected}
+	tabindex={selected ? 0 : -1}
 	class={cn(
 		'duration-subtle ease-market-ease focus-visible:ring-ring/60 focus-visible:ring-offset-background inline-flex min-w-[6rem] items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-		$selected
+		selected
 			? 'bg-surface-accent text-surface-accent-foreground shadow-marketplace-sm'
 			: 'text-muted-foreground hover:text-foreground hover:bg-surface-muted/40',
 		disabled && 'cursor-not-allowed opacity-60',
@@ -36,5 +37,5 @@
 	)}
 	onclick={handleClick}
 >
-	<slot />
+	{@render children?.()}
 </button>

--- a/src/lib/components/ui/tabs/tabs.svelte
+++ b/src/lib/components/ui/tabs/tabs.svelte
@@ -1,32 +1,34 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
-	import { writable } from 'svelte/store';
 	import { initTabsContext } from './context';
+	import type { Snippet } from 'svelte';
 
-	let {
+	const {
 		value = '',
 		class: className = '',
-		onValueChange
-	}: {
+		onValueChange,
+		children
+	} = $props<{
 		value?: string;
 		class?: string;
 		onValueChange?: (value: string) => void;
-	} = $props();
+		children?: Snippet;
+	}>();
 
-	const internal = writable(value);
+	let selected = $state(value);
 
 	$effect(() => {
-		internal.set(value);
+		selected = value;
 	});
 
-	function setValue(next: string) {
-		internal.set(next);
+	const setValue = (next: string) => {
+		selected = next;
 		onValueChange?.(next);
-	}
+	};
 
-	initTabsContext({ value: internal, setValue });
+	initTabsContext({ value: () => selected, setValue });
 </script>
 
 <div class={cn('grid gap-4', className)}>
-	<slot />
+	{@render children?.()}
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,9 +12,6 @@
 	import type { Snippet } from 'svelte';
 
 	const { children, data } = $props<{ children: Snippet; data: LayoutData }>();
-	const uiState = $derived(uiStore);
-	const chatOpen = $derived(() => uiState.chatOpen);
-	const sidebarOpen = $derived(() => uiState.sidebarOpen);
 
 	const promoTicker = [
 		{ id: 'rain-pot', label: 'Rain pot nearly full', meta: '$12.4k pool · 8 slots left' },
@@ -32,47 +29,43 @@
 
 <div class="bg-background text-foreground">
 	<div
-		class="mx-auto grid min-h-[100dvh] w-full max-w-[1920px] grid-cols-1 gap-4 px-4 pt-4 pb-[92px] sm:px-6 lg:px-8 xl:grid-cols-[260px,minmax(0,1fr),320px] xl:gap-6 xl:px-10"
+		class="mx-auto grid min-h-[100dvh] w-full max-w-[1920px] grid-cols-1 gap-6 px-4 pt-4 pb-[92px] sm:px-6 lg:px-8 xl:grid-cols-[260px,minmax(0,1fr),320px] xl:items-start xl:gap-8 xl:px-10 xl:pt-6 xl:pb-6"
 	>
-		<aside class="hidden xl:block">
-			<div class="sticky top-4 flex h-[calc(100dvh-2rem)] flex-col">
-				<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="flex-1" />
-			</div>
+		<aside class="hidden xl:sticky xl:top-0 xl:flex xl:min-h-[100dvh] xl:flex-col">
+			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="flex-1" />
 		</aside>
 
 		<div
-			class="xl:bg-surface/70 relative flex min-h-[100dvh] flex-col rounded-none xl:col-start-2 xl:rounded-[32px] xl:border xl:border-white/10 xl:shadow-[0_32px_120px_rgba(15,23,42,0.35)] xl:backdrop-blur"
+			class="xl:bg-surface/70 relative flex min-h-[100dvh] flex-col rounded-none xl:col-start-2 xl:min-h-0 xl:overflow-hidden xl:rounded-[32px] xl:border xl:border-white/10 xl:shadow-[0_32px_120px_rgba(15,23,42,0.35)] xl:backdrop-blur"
 		>
 			<div class="sticky top-0 z-30 xl:rounded-t-[32px]">
 				<ShellHeader {promoTicker} isAuthenticated={data.isAuthenticated} user={data.user} />
 			</div>
 			<main
-				class="marketplace-scrollbar flex-1 overflow-y-auto px-1 pt-6 pb-20 sm:px-3 md:px-4 xl:px-8"
+				class="marketplace-scrollbar flex-1 overflow-y-auto px-1 pt-6 pb-24 sm:px-3 md:px-4 xl:px-8 xl:pb-12"
 				aria-label="Primary content"
 			>
-				<div class="mx-auto flex w-full max-w-[1140px] flex-col gap-12 pb-6">
+				<div class="mx-auto flex w-full max-w-none flex-col gap-10 pb-10">
 					{@render children?.()}
 				</div>
 			</main>
 		</div>
 
-		<aside class="hidden xl:block">
-			<div class="sticky top-4 flex h-[calc(100dvh-2rem)] flex-col">
-				<CommunityRail />
-			</div>
+		<aside class="hidden xl:sticky xl:top-0 xl:flex xl:min-h-[100dvh] xl:flex-col">
+			<CommunityRail />
 		</aside>
 	</div>
 
 	<BottomNav
 		isAuthenticated={data.isAuthenticated}
-		class="fixed inset-x-0 bottom-0 z-40 border-t pb-[env(safe-area-inset-bottom)] xl:hidden"
+		class="fixed inset-x-0 bottom-0 z-40 border-t pb-[env(safe-area-inset-bottom)] lg:hidden"
 	/>
 
 	<button
 		type="button"
-		class="bg-primary text-primary-foreground shadow-marketplace-lg fixed right-4 bottom-[92px] z-40 flex items-center gap-3 rounded-full px-4 py-3 text-sm font-medium md:right-6 md:bottom-[96px] xl:hidden"
+		class="bg-primary text-primary-foreground shadow-marketplace-lg fixed right-4 bottom-[88px] z-40 flex items-center gap-3 rounded-full px-5 py-3 text-sm font-semibold sm:right-6 sm:bottom-[92px] lg:hidden"
 		onclick={handleChatToggle}
-		aria-pressed={chatOpen}
+		aria-pressed={$uiStore.chatOpen}
 	>
 		<span class="flex h-9 w-9 items-center justify-center rounded-full bg-white/15">
 			<MessageCircle class="h-4 w-4" />
@@ -82,16 +75,21 @@
 
 	<ChatDrawer />
 
-	{#if sidebarOpen}
+	{#if $uiStore.sidebarOpen}
 		<div
 			class="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm xl:hidden"
 			role="presentation"
 			onclick={handleSidebarClose}
 		></div>
 		<div
-			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[320px] max-w-[88vw] overflow-y-auto px-6 pt-6 pb-8 backdrop-blur-xl xl:hidden"
+			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[320px] max-w-[88vw] overflow-y-auto px-4 pt-4 pb-8 backdrop-blur-xl xl:hidden"
 		>
-			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full" />
+			<Sidebar
+				isAuthenticated={data.isAuthenticated}
+				user={data.user}
+				class="h-full"
+				density="compact"
+			/>
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- rebuild the root layout shell to keep the sidebar and community rail sticky while isolating scrolling to the center column and gating the chat overlay behind the mobile toggle
- refresh the sidebar, bottom nav, and chat drawer runes so authentication previews, navigation, and chat controls reactively mirror store state without legacy slot syntax
- migrate shared UI primitives (buttons, cards, sheets, tabs, dropdowns) to Svelte 5 runes and Snippet rendering to resolve deprecated `<slot>` usage and event directives

## Testing
- pnpm check *(fails: missing paraglide modules, unused selectors, and legacy home grid typing issues in the existing codebase)*
- pnpm lint *(fails: pre-existing lint violations across demo and seed routes unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68da7437ca8c83269145e196f8bc7bac