### PR TITLE
Refactor shell layout and consolidate chat UI

### DIFF
--- a/src/lib/components/chat/ChatComposer.svelte
+++ b/src/lib/components/chat/ChatComposer.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { Button } from '$lib/components/ui';
+	import { cn } from '$lib/utils';
+	import { Send } from 'lucide-svelte';
+
+	type ChatComposerEvents = {
+		submit: string;
+		input: string;
+	};
+
+	type ChatComposerProps = {
+		value: string;
+		placeholder?: string;
+		label?: string;
+		sendLabel?: string;
+		id?: string;
+		variant?: 'dark' | 'surface';
+		class?: string;
+		multiline?: boolean;
+		disabled?: boolean;
+	};
+
+	const props = $props<ChatComposerProps>();
+	const placeholder = $derived(() => props.placeholder ?? 'Type a message…');
+	const label = $derived(() => props.label ?? 'Message');
+	const sendLabel = $derived(() => props.sendLabel ?? 'Send message');
+	const id = $derived(() => props.id ?? 'chat-composer');
+	const className = $derived(() => props.class ?? '');
+	const variant = $derived(() => (props.variant ?? 'surface') as 'dark' | 'surface');
+	const multiline = $derived(() => props.multiline ?? true);
+	const disabled = $derived(() => props.disabled ?? false);
+	const inboundValue = $derived(() => props.value ?? '');
+
+	let localValue = $state(inboundValue);
+
+	const dispatch = createEventDispatcher<ChatComposerEvents>();
+
+	$effect(() => {
+		localValue = inboundValue;
+	});
+
+	const variantClasses = {
+		dark: {
+			container: 'border-white/20 bg-black/30',
+			input: 'placeholder:text-white/50 text-white',
+			button: 'border border-white/30 bg-white/15 text-white hover:bg-white/25',
+			buttonDisabled: 'opacity-60 hover:bg-white/15'
+		},
+		surface: {
+			container: 'border-border/60 bg-surface-muted/50',
+			input: 'placeholder:text-muted-foreground text-foreground',
+			button: 'bg-primary text-primary-foreground hover:bg-primary/90',
+			buttonDisabled: 'opacity-70 hover:bg-primary'
+		}
+	} as const;
+
+	const isSendDisabled = $derived(() => disabled || localValue.trim().length === 0);
+
+	const handleSubmit = () => {
+		const trimmed = localValue.trim();
+		if (!trimmed || disabled) return;
+		dispatch('submit', trimmed);
+	};
+
+	const handleFormSubmit = (event: SubmitEvent) => {
+		event.preventDefault();
+		handleSubmit();
+	};
+
+	const handleInput = (event: Event) => {
+		const target = event.target as HTMLTextAreaElement | HTMLInputElement;
+		localValue = target.value;
+		dispatch('input', target.value);
+	};
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (event.key === 'Enter' && (!multiline || !event.shiftKey)) {
+			event.preventDefault();
+			handleSubmit();
+		}
+	};
+</script>
+
+<form
+	class={cn(
+		'flex items-center gap-2 rounded-2xl border px-3 py-2 transition-colors',
+		variantClasses[variant].container,
+		className
+	)}
+	onsubmit={handleFormSubmit}
+>
+	<label class="sr-only" for={id}>{label}</label>
+	{#if multiline}
+		<textarea
+			{id}
+			rows={1}
+			{placeholder}
+			value={localValue}
+			oninput={handleInput}
+			onkeydown={handleKeydown}
+			class={cn(
+				'marketplace-scrollbar max-h-24 flex-1 resize-none border-0 bg-transparent px-2 py-1 text-sm focus:outline-none',
+				variantClasses[variant].input
+			)}
+			{disabled}
+		/>
+	{:else}
+		<input
+			{id}
+			type="text"
+			{placeholder}
+			value={localValue}
+			oninput={handleInput}
+			onkeydown={handleKeydown}
+			class={cn(
+				'h-10 flex-1 border-0 bg-transparent px-2 text-sm focus:outline-none',
+				variantClasses[variant].input
+			)}
+			{disabled}
+		/>
+	{/if}
+	<Button
+		type="submit"
+		size="icon"
+		variant="ghost"
+		class={cn(
+			'focus-visible:ring-ring/70 focus-visible:ring-offset-background h-11 w-11 rounded-2xl transition-colors focus-visible:ring-2 focus-visible:ring-offset-2',
+			variantClasses[variant].button,
+			isSendDisabled ? variantClasses[variant].buttonDisabled : ''
+		)}
+		disabled={isSendDisabled}
+	>
+		<Send class="h-4 w-4" />
+		<span class="sr-only">{sendLabel}</span>
+	</Button>
+</form>

--- a/src/lib/components/chat/ChatList.svelte
+++ b/src/lib/components/chat/ChatList.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { CommunityMessage } from '$lib/stores/homepage';
+
+	type ChatListProps = {
+		messages: CommunityMessage[];
+		variant?: 'dark' | 'surface';
+		class?: string;
+		ariaLive?: 'polite' | 'assertive' | 'off';
+		labelledby?: string;
+	};
+
+	const props = $props<ChatListProps>();
+	const messages = $derived(() => props.messages ?? []);
+	const variant = $derived(() => (props.variant ?? 'surface') as 'dark' | 'surface');
+	const className = $derived(() => props.class ?? '');
+	const ariaLive = $derived(() => props.ariaLive ?? 'polite');
+	const labelledby = $derived(() => props.labelledby);
+
+	const variantClasses = {
+		dark: {
+			item: 'border-white/15 bg-black/20 text-white shadow-[0_12px_35px_rgba(12,74,110,0.3)]',
+			meta: 'text-[11px] tracking-[0.3em] text-white/60 uppercase',
+			username: 'text-white',
+			timestamp: 'text-white/60 text-[11px] normal-case',
+			message: 'text-white/80',
+			list: 'pr-2',
+			badge: {
+				vip: 'bg-primary/25 text-white',
+				staff: 'bg-accent/25 text-white',
+				pro: 'bg-secondary/25 text-white'
+			}
+		},
+		surface: {
+			item: 'border-border/50 bg-surface/70 text-foreground',
+			meta: 'text-muted-foreground flex items-center justify-between text-xs',
+			username: 'text-foreground font-semibold',
+			timestamp: 'text-muted-foreground text-xs',
+			message: 'text-foreground/90',
+			list: 'pr-1',
+			badge: {
+				vip: 'bg-primary/20 text-primary',
+				staff: 'bg-accent/20 text-accent-foreground',
+				pro: 'bg-secondary/20 text-secondary-foreground'
+			}
+		}
+	} as const;
+</script>
+
+<ul
+	class={cn(
+		'marketplace-scrollbar flex flex-1 flex-col space-y-3 overflow-y-auto',
+		variantClasses[variant].list,
+		className
+	)}
+	role="log"
+	aria-live={ariaLive}
+	aria-relevant="additions text"
+	aria-labelledby={labelledby}
+>
+	{#if messages.length === 0}
+		<li
+			class={cn(
+				'border-border/50 text-muted-foreground/80 flex flex-col items-center justify-center gap-2 rounded-2xl border px-6 py-8 text-center text-sm',
+				variant === 'dark' ? 'border-white/15 bg-white/5 text-white/70' : 'bg-surface-muted/40'
+			)}
+		>
+			<span>No messages yet. Start the conversation.</span>
+		</li>
+	{/if}
+
+	{#each messages as message (message.id)}
+		<li
+			class={cn(
+				'rounded-2xl border px-4 py-3 text-sm transition-colors',
+				variantClasses[variant].item
+			)}
+		>
+			<div
+				class={cn(
+					'mb-1 flex items-center justify-between gap-3 text-xs',
+					variant === 'dark' ? 'text-white/70' : 'text-muted-foreground'
+				)}
+			>
+				<div class="flex items-center gap-2">
+					<span class={variantClasses[variant].username}>{message.username}</span>
+					{#if message.badge}
+						<span
+							class={cn(
+								'rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-[0.3em] uppercase',
+								variantClasses[variant].badge[message.badge]
+							)}
+						>
+							{message.badge}
+						</span>
+					{/if}
+				</div>
+				<span class={variantClasses[variant].timestamp}>{message.timestamp}</span>
+			</div>
+			<p class={cn('leading-relaxed', variantClasses[variant].message)}>{message.message}</p>
+		</li>
+	{/each}
+</ul>

--- a/src/lib/components/home/CommunityRail.svelte
+++ b/src/lib/components/home/CommunityRail.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import { get } from 'svelte/store';
 	import { Button } from '$lib/components/ui';
-	import { CloudRain, Send, Users } from 'lucide-svelte';
+	import ChatList from '$lib/components/chat/ChatList.svelte';
+	import ChatComposer from '$lib/components/chat/ChatComposer.svelte';
+	import { CloudRain, Users } from 'lucide-svelte';
+	import { cn } from '$lib/utils';
 	import {
 		communityMessages,
 		pushCommunityMessage,
@@ -10,9 +13,18 @@
 		type RainPot
 	} from '$lib/stores/homepage';
 
+	type CommunityRailProps = {
+		class?: string;
+		appearance?: 'rail' | 'panel';
+	};
+
+	const props = $props<CommunityRailProps>();
+	const className = $derived(() => props.class ?? '');
+	const appearance = $derived(() => (props.appearance ?? 'rail') as 'rail' | 'panel');
+
 	let messages = $state<CommunityMessage[]>(get(communityMessages));
 	let currentPot = $state<RainPot>(get(rainPot));
-	let input = $state('');
+	let composerValue = $state('');
 
 	$effect(() => {
 		const unsubscribe = communityMessages.subscribe((value) => {
@@ -28,55 +40,85 @@
 		return unsubscribe;
 	});
 
-	const sendMessage = () => {
-		const trimmed = input.trim();
+	const sendMessage = (value: string) => {
+		const trimmed = value.trim();
 		if (!trimmed) return;
 		pushCommunityMessage({ username: 'Guest', message: trimmed });
-		input = '';
 	};
 
-	const handleSubmit = (event: SubmitEvent) => {
-		event.preventDefault();
-		sendMessage();
+	const handleComposerSubmit = (event: CustomEvent<string>) => {
+		sendMessage(event.detail);
+		composerValue = '';
 	};
 
-	const handleKey = (event: KeyboardEvent) => {
-		if (event.key === 'Enter' && !event.shiftKey) {
-			event.preventDefault();
-			sendMessage();
-		}
+	const handleComposerInput = (event: CustomEvent<string>) => {
+		composerValue = event.detail;
 	};
 
-	const handleInput = (event: Event) => {
-		const target = event.target as HTMLInputElement | HTMLTextAreaElement;
-		input = target.value;
-	};
+	const chatVariant = $derived(() => (appearance === 'rail' ? 'dark' : 'surface'));
+	const multilineComposer = $derived(() => appearance !== 'rail');
+
+	const containerClasses = {
+		rail: 'border border-white/10 bg-[radial-gradient(circle_at_20%_20%,rgba(45,212,191,0.16),transparent_55%),radial-gradient(circle_at_80%_40%,rgba(59,130,246,0.18),transparent_60%),rgba(15,23,42,0.82)] text-white shadow-[0_36px_140px_rgba(15,23,42,0.45)] backdrop-blur-2xl',
+		panel:
+			'border border-border/60 bg-surface/80 text-foreground shadow-marketplace-lg backdrop-blur-xl'
+	} as const;
+
+	const potCardClasses = {
+		rail: 'rounded-3xl border border-white/25 bg-white/10 p-5 text-sm shadow-[0_18px_45px_rgba(12,74,110,0.25)]',
+		panel: 'rounded-3xl border border-border/60 bg-surface-muted/60 p-5 text-sm'
+	} as const;
+
+	const potLabelClasses = {
+		rail: 'text-[11px] tracking-[0.3em] text-white/70 uppercase',
+		panel: 'text-[11px] tracking-[0.3em] text-muted-foreground uppercase'
+	} as const;
 </script>
 
 <aside
-	class="hidden h-full w-full flex-col overflow-hidden rounded-[32px] border border-white/10 bg-[radial-gradient(circle_at_20%_20%,rgba(45,212,191,0.16),transparent_55%),radial-gradient(circle_at_80%_40%,rgba(59,130,246,0.18),transparent_60%),rgba(15,23,42,0.82)] p-6 text-white shadow-[0_36px_140px_rgba(15,23,42,0.45)] backdrop-blur-2xl xl:flex"
+	class={cn(
+		'flex h-full w-full flex-col overflow-hidden rounded-[32px] p-6',
+		containerClasses[appearance],
+		className
+	)}
 >
 	<header class="space-y-1">
-		<p class="text-[11px] tracking-[0.35em] text-white/60 uppercase">Community rail</p>
-		<h2 class="text-lg font-semibold">Trading floor chat</h2>
+		<p
+			class={cn(
+				'text-[11px] tracking-[0.35em] uppercase',
+				appearance === 'rail' ? 'text-white/60' : 'text-muted-foreground'
+			)}
+		>
+			Community rail
+		</p>
+		<h2 id="community-rail-title" class="text-lg font-semibold">
+			{appearance === 'rail' ? 'Trading floor chat' : 'Community updates'}
+		</h2>
 	</header>
 
-	<section
-		class="mt-4 rounded-3xl border border-white/25 bg-white/10 p-5 text-sm shadow-[0_18px_45px_rgba(12,74,110,0.25)]"
-	>
+	<section class={potCardClasses[appearance]} aria-describedby="rain-pot-meta">
 		<div class="flex items-center gap-4">
 			<span
-				class="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/30 bg-white/15 text-white"
+				class={cn(
+					'flex h-14 w-14 items-center justify-center rounded-2xl border',
+					appearance === 'rail'
+						? 'border-white/30 bg-white/15 text-white'
+						: 'border-border/60 bg-surface/70 text-primary'
+				)}
 			>
 				<CloudRain class="h-5 w-5" />
 			</span>
 			<div>
-				<p class="text-[11px] tracking-[0.3em] text-white/70 uppercase">Rain pot</p>
+				<p class={potLabelClasses[appearance]}>Rain pot</p>
 				<p class="text-2xl font-semibold">{currentPot.total}</p>
 			</div>
 		</div>
 		<div
-			class="mt-4 flex items-center justify-between text-[11px] tracking-[0.3em] text-white/70 uppercase"
+			id="rain-pot-meta"
+			class={cn(
+				'mt-4 flex items-center justify-between text-[11px] tracking-[0.3em] uppercase',
+				appearance === 'rail' ? 'text-white/70' : 'text-muted-foreground'
+			)}
 		>
 			<span class="flex items-center gap-2">
 				<Users class="h-3.5 w-3.5" />
@@ -85,66 +127,35 @@
 			<span>Ends in {currentPot.endsIn}</span>
 		</div>
 		<Button
-			class="mt-5 w-full rounded-2xl bg-white/15 text-white hover:bg-white/25"
-			variant="secondary"
+			class={cn(
+				'mt-5 w-full rounded-2xl font-semibold',
+				appearance === 'rail'
+					? 'bg-white/15 text-white hover:bg-white/25'
+					: 'bg-primary text-primary-foreground hover:bg-primary/90'
+			)}
+			variant={appearance === 'rail' ? 'secondary' : 'default'}
 		>
 			Join rain pot
 		</Button>
 	</section>
 
 	<div class="mt-5 flex flex-1 flex-col overflow-hidden">
-		<div class="marketplace-scrollbar flex-1 space-y-3 overflow-y-auto pr-2">
-			{#each messages as message (message.id)}
-				<article
-					class="rounded-2xl border border-white/15 bg-black/20 px-4 py-3 text-sm shadow-[0_12px_35px_rgba(12,74,110,0.3)]"
-				>
-					<div
-						class="mb-1 flex items-center justify-between text-[11px] tracking-[0.3em] text-white/60 uppercase"
-					>
-						<div class="flex items-center gap-2 text-xs normal-case">
-							<span class="font-semibold text-white">{message.username}</span>
-							{#if message.badge}
-								<span
-									class={`rounded-full px-2 py-0.5 text-[10px] tracking-[0.3em] uppercase ${
-										message.badge === 'vip'
-											? 'bg-primary/25 text-white'
-											: message.badge === 'staff'
-												? 'bg-accent/25 text-white'
-												: 'bg-secondary/25 text-white'
-									}`}
-								>
-									{message.badge}
-								</span>
-							{/if}
-						</div>
-						<span class="text-[11px] normal-case">{message.timestamp}</span>
-					</div>
-					<p class="leading-relaxed text-white/80">{message.message}</p>
-				</article>
-			{/each}
-		</div>
-		<form
-			class="mt-4 flex items-center gap-2 rounded-2xl border border-white/20 bg-black/30 px-4 py-3"
-			onsubmit={handleSubmit}
-		>
-			<label class="sr-only" for="community-message">Message</label>
-			<input
-				id="community-message"
-				class="h-10 flex-1 border-0 bg-transparent text-sm text-white placeholder:text-white/50 focus:outline-none"
-				placeholder="Share a drop..."
-				value={input}
-				oninput={handleInput}
-				onkeydown={handleKey}
-			/>
-			<Button
-				size="icon"
-				variant="secondary"
-				class="h-10 w-10 rounded-full border border-white/30 bg-white/15"
-				type="submit"
-			>
-				<Send class="h-4 w-4" />
-				<span class="sr-only">Send</span>
-			</Button>
-		</form>
+		<ChatList
+			{messages}
+			variant={chatVariant}
+			ariaLive="polite"
+			class="flex-1"
+			labelledby={appearance === 'rail' ? undefined : 'community-rail-title'}
+		/>
+		<ChatComposer
+			id={appearance === 'rail' ? 'community-message' : 'community-message-panel'}
+			class="mt-4"
+			value={composerValue}
+			on:input={handleComposerInput}
+			on:submit={handleComposerSubmit}
+			placeholder="Share a drop..."
+			variant={chatVariant}
+			multiline={multilineComposer}
+		/>
 	</div>
 </aside>

--- a/src/lib/components/home/LiveMarketplaceGrid.svelte
+++ b/src/lib/components/home/LiveMarketplaceGrid.svelte
@@ -2,6 +2,7 @@
 	import { marketplaceItems } from '$lib/stores/homepage';
 	import { Badge, Button } from '$lib/components/ui';
 	import { ArrowRight, Users } from 'lucide-svelte';
+	import { formatInt } from '$lib/utils/format';
 
 	const items = $derived($marketplaceItems);
 
@@ -76,7 +77,7 @@
 						<div>
 							<p class="text-[11px] tracking-[0.3em] uppercase">Watching</p>
 							<p class="text-foreground text-sm font-medium">
-								{item.playersOnline.toLocaleString()} live
+								{formatInt(item.playersOnline ?? item.watching ?? 0)} live
 							</p>
 						</div>
 					</div>

--- a/src/lib/components/shell/BottomNav.svelte
+++ b/src/lib/components/shell/BottomNav.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { Home, Package, Swords, ArrowUpRight, Briefcase } from 'lucide-svelte';
 	import { cn } from '$lib/utils';
@@ -26,32 +25,51 @@
 		{ href: '/inventory', label: 'Inventory', icon: Briefcase }
 	] as const;
 
-	const isActiveRoute = (href: string) => currentPath === href;
-	const buildHref = (path: string) => (base ? `${base}${path}` : path);
-	const handleNavigation = (href: string) => {
-		// eslint-disable-next-line svelte/no-navigation-without-resolve
-		goto(buildHref(href));
+	const normalizePath = (path: string) => {
+		if (!path) return '/';
+		if (path === '/') return '/';
+		return path.endsWith('/') ? path.slice(0, -1) : path;
 	};
+
+	const relativePath = $derived(() => {
+		if (!base) return normalizePath(currentPath);
+		if (currentPath.startsWith(base)) {
+			const trimmed = currentPath.slice(base.length) || '/';
+			const normalized = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+			return normalizePath(normalized);
+		}
+		return normalizePath(currentPath);
+	});
+
+	const isActiveRoute = (href: string) => {
+		const target = normalizePath(href);
+		if (target === '/') {
+			return relativePath === '/' || relativePath === '';
+		}
+
+		return relativePath === target || relativePath.startsWith(`${target}/`);
+	};
+
+	const buildHref = (path: string) => (base ? `${base}${path}` : path);
 </script>
 
 <nav
-	aria-label="Mobile"
+	aria-label="Mobile navigation"
 	class={cn(
 		'border-border/70 bg-surface/90 flex items-center justify-between gap-1 border-t px-2 py-2 shadow-[0_-20px_60px_rgba(15,23,42,0.55)] backdrop-blur-xl',
 		className
 	)}
 >
 	{#each items as item (item.href)}
-		<button
-			type="button"
-			onclick={() => handleNavigation(item.href)}
+		<a
+			href={buildHref(item.href)}
 			class={cn(
 				'text-muted-foreground focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium tracking-[0.25em] uppercase transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
 				isActiveRoute(item.href)
 					? 'bg-primary/20 text-foreground shadow-marketplace-sm'
 					: 'hover:bg-surface-muted/40 hover:text-foreground'
 			)}
-			aria-pressed={isActiveRoute(item.href)}
+			aria-current={isActiveRoute(item.href) ? 'page' : undefined}
 		>
 			<span
 				class={cn(
@@ -66,6 +84,6 @@
 			<span class="leading-tight tracking-normal normal-case">
 				{item.href === '/inventory' ? (isAuthenticated ? 'Inventory' : 'Locker') : item.label}
 			</span>
-		</button>
+		</a>
 	{/each}
 </nav>

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { formatCurrency, formatInt } from './format';
+
+describe('format helpers', () => {
+	describe('formatCurrency', () => {
+		it('formats positive numbers with currency symbol', () => {
+			expect(formatCurrency(1234.56)).toBe('$1,234.56');
+		});
+
+		it('guards against nullish values', () => {
+			expect(formatCurrency(null)).toBe('$0.00');
+			expect(formatCurrency(undefined)).toBe('$0.00');
+		});
+
+		it('falls back to zero on invalid numbers', () => {
+			expect(formatCurrency(Number.NaN)).toBe('$0.00');
+		});
+	});
+
+	describe('formatInt', () => {
+		it('formats integers with group separators', () => {
+			expect(formatInt(1234567)).toBe('1,234,567');
+		});
+
+		it('handles negative numbers', () => {
+			expect(formatInt(-3200)).toBe('-3,200');
+		});
+
+		it('guards against nullish values', () => {
+			expect(formatInt(null)).toBe('0');
+			expect(formatInt(undefined)).toBe('0');
+		});
+	});
+});

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,35 @@
+export function formatCurrency(
+	value: number | null | undefined,
+	currency = 'USD',
+	locale = 'en-US'
+): string {
+	const numericValue = normalizeNumber(value);
+	const formatter = new Intl.NumberFormat(locale, {
+		style: 'currency',
+		currency,
+		maximumFractionDigits: 2,
+		minimumFractionDigits: 2
+	});
+	return formatter.format(numericValue);
+}
+
+export function formatInt(value: number | null | undefined, locale = 'en-US'): string {
+	const numericValue = normalizeNumber(value);
+	const formatter = new Intl.NumberFormat(locale, {
+		maximumFractionDigits: 0
+	});
+	return formatter.format(numericValue);
+}
+
+function normalizeNumber(value: number | null | undefined): number {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return value;
+	}
+
+	if (value === null || value === undefined) {
+		return 0;
+	}
+
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,8 +13,8 @@
 
 	const { children, data } = $props<{ children: Snippet; data: LayoutData }>();
 	const uiState = $derived(uiStore);
-	const chatOpen = $derived(() => uiState.chatOpen);
-	const sidebarOpen = $derived(() => uiState.sidebarOpen);
+	const isChatOpen = $derived(() => uiState.chatOpen);
+	const isSidebarOpen = $derived(() => uiState.sidebarOpen);
 
 	const promoTicker = [
 		{ id: 'rain-pot', label: 'Rain pot nearly full', meta: '$12.4k pool · 8 slots left' },
@@ -24,6 +24,23 @@
 
 	const handleChatToggle = () => toggleChat();
 	const handleSidebarClose = () => closeSidebar();
+
+	let chatLauncher: HTMLButtonElement | null = null;
+	let lastChatOpen: boolean | null = null;
+
+	$effect(() => {
+		const open = isChatOpen;
+		if (lastChatOpen === null) {
+			lastChatOpen = open;
+			return;
+		}
+
+		if (!open && lastChatOpen && chatLauncher) {
+			chatLauncher.focus();
+		}
+
+		lastChatOpen = open;
+	});
 </script>
 
 <svelte:head>
@@ -32,30 +49,33 @@
 
 <div class="bg-background text-foreground">
 	<div
-		class="mx-auto grid min-h-[100dvh] w-full max-w-[1920px] grid-cols-1 gap-6 px-4 pt-4 pb-[92px] sm:px-6 lg:px-8 xl:grid-cols-[260px,minmax(0,1fr),320px] xl:items-start xl:gap-8 xl:px-10 xl:pt-6 xl:pb-6"
+		class="mx-auto grid min-h-[100dvh] w-full max-w-[1920px] grid-cols-1 gap-6 px-4 pt-4 pb-[92px] sm:px-6 lg:grid-cols-[260px,minmax(0,1fr)] lg:items-start lg:gap-8 lg:px-8 lg:pt-6 lg:pb-6 xl:grid-cols-[260px,minmax(0,1fr),320px] xl:gap-8 xl:px-10 xl:pt-6 xl:pb-6"
 	>
-		<aside class="hidden xl:sticky xl:top-0 xl:flex xl:min-h-[100dvh] xl:flex-col">
+		<aside class="hidden lg:sticky lg:top-0 lg:flex lg:min-h-[100dvh] lg:flex-col">
 			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="flex-1" />
 		</aside>
 
 		<div
-			class="xl:bg-surface/70 relative flex min-h-[100dvh] flex-col rounded-none xl:col-start-2 xl:min-h-0 xl:overflow-hidden xl:rounded-[32px] xl:border xl:border-white/10 xl:shadow-[0_32px_120px_rgba(15,23,42,0.35)] xl:backdrop-blur"
+			class="lg:bg-surface/70 relative flex min-h-[100dvh] flex-col rounded-none lg:col-start-2 lg:min-h-0 lg:overflow-hidden lg:rounded-[32px] lg:border lg:border-white/10 lg:shadow-[0_32px_120px_rgba(15,23,42,0.35)] lg:backdrop-blur"
 		>
-			<div class="sticky top-0 z-30 xl:rounded-t-[32px]">
+			<div class="sticky top-0 z-30 lg:rounded-t-[32px]">
 				<ShellHeader {promoTicker} isAuthenticated={data.isAuthenticated} user={data.user} />
 			</div>
 			<main
-				class="marketplace-scrollbar flex-1 overflow-y-auto px-1 pt-6 pb-24 sm:px-3 md:px-4 xl:px-8 xl:pb-12"
+				class="marketplace-scrollbar flex-1 overflow-y-auto px-1 pt-6 pb-24 sm:px-3 md:px-4 lg:px-8 lg:pb-12"
 				aria-label="Primary content"
 			>
 				<div class="mx-auto flex w-full max-w-none flex-col gap-10 pb-10">
 					{@render children?.()}
+					<section class="hidden md:mt-12 md:block xl:hidden">
+						<CommunityRail appearance="panel" class="w-full" />
+					</section>
 				</div>
 			</main>
 		</div>
 
 		<aside class="hidden xl:sticky xl:top-0 xl:flex xl:min-h-[100dvh] xl:flex-col">
-			<CommunityRail />
+			<CommunityRail appearance="rail" class="flex-1" />
 		</aside>
 	</div>
 
@@ -68,7 +88,8 @@
 		type="button"
 		class="bg-primary text-primary-foreground shadow-marketplace-lg fixed right-4 bottom-[88px] z-40 flex items-center gap-3 rounded-full px-5 py-3 text-sm font-semibold sm:right-6 sm:bottom-[92px] lg:hidden"
 		onclick={handleChatToggle}
-		aria-pressed={chatOpen}
+		aria-pressed={isChatOpen}
+		bind:this={chatLauncher}
 	>
 		<span class="flex h-9 w-9 items-center justify-center rounded-full bg-white/15">
 			<MessageCircle class="h-4 w-4" />
@@ -78,21 +99,20 @@
 
 	<ChatDrawer />
 
-	{#if sidebarOpen}
+	{#if isSidebarOpen}
 		<div
-			class="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm xl:hidden"
+			class="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm lg:hidden"
 			role="presentation"
+			aria-hidden="true"
 			onclick={handleSidebarClose}
 		></div>
-		<div
-			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[320px] max-w-[88vw] overflow-y-auto px-4 pt-4 pb-8 backdrop-blur-xl xl:hidden"
+		<aside
+			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[320px] max-w-[88vw] overflow-y-auto px-4 pt-4 pb-8 backdrop-blur-xl lg:hidden"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Primary navigation"
 		>
-			<Sidebar
-				isAuthenticated={data.isAuthenticated}
-				user={data.user}
-				class="h-full"
-				density="compact"
-			/>
-		</div>
+			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full" overlay />
+		</aside>
 	{/if}
 </div>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ProfileCard from '$lib/components/ProfileCard.svelte';
 	import { Trophy, Target, TrendingUp, DollarSign } from 'lucide-svelte';
+	import { formatCurrency } from '$lib/utils/format';
 	import type { PageData } from './$types';
 	import {
 		Card,
@@ -40,7 +41,7 @@
 						<DollarSign class="h-4 w-4" /> Total wagered
 					</div>
 					<p class="text-foreground text-2xl font-semibold">
-						${data.profile?.total_wagered?.toLocaleString() || '0'}
+						{formatCurrency(data.profile?.total_wagered ?? 0)}
 					</p>
 				</CardContent>
 			</Card>
@@ -54,7 +55,7 @@
 					<p
 						class={`text-2xl font-semibold ${data.profile?.total_profit && data.profile.total_profit >= 0 ? 'text-success' : 'text-destructive'}`}
 					>
-						${data.profile?.total_profit?.toLocaleString() || '0'}
+						{formatCurrency(data.profile?.total_profit ?? 0)}
 					</p>
 				</CardContent>
 			</Card>
@@ -76,7 +77,7 @@
 						<Trophy class="h-4 w-4" /> Biggest win
 					</div>
 					<p class="text-foreground text-2xl font-semibold">
-						${data.profile?.biggest_win?.toLocaleString() || '0'}
+						{formatCurrency(data.profile?.biggest_win ?? 0)}
 					</p>
 				</CardContent>
 			</Card>


### PR DESCRIPTION
## Summary
- restructure the root layout to support a sticky three-column shell on desktop while keeping an accessible mobile overlay and chat launcher
- consolidate community chat rendering into shared ChatList/ChatComposer components used by the right rail and mobile drawer
- add centralized currency/integer formatting helpers and update surfaces to consume them, including new Vitest coverage

## Testing
- npm run lint *(fails: repo contains pre-existing lint errors in scripts and demo routes)*
- npm run check *(fails: repo missing several Paraglide modules referenced in demo code)*
- npm run test *(fails: Vitest reports an unhandled browser runner error in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dab7eaca988326b803656110e6b780