### PR TITLE
refactor: rebuild shell layout with tokenized theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Design tokens & shell layout
+
+The application shell is driven by a shared design token system declared in `tailwind.config.ts` and `src/app.css`. Colors, spacing, typography, radii, shadows, and z-index layers are surfaced as CSS variables (e.g. `--space-lg`, `--color-primary`) and mapped to Tailwind utilities (`p-lg`, `bg-primary`, `shadow-elevated-sm`). New components should prefer these tokens over hard-coded values to ensure consistency between light and dark themes.
+
+Desktop layouts use a sticky left sidebar (`min-width: 280px`), a top header sized by `--size-header`, and a two-column content grid that keeps the chat composer visible without additional scrolling. Mobile layouts hide the sidebar, rely on the bottom navigation, and respect safe-area insets for sticky controls.

--- a/src/app.css
+++ b/src/app.css
@@ -4,73 +4,150 @@
 	:root {
 		color-scheme: dark;
 
-		--background: 18.8% 0.018 255;
-		--foreground: 95.2% 0.014 255;
+		--font-sans:
+			'Inter Variable', 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+			'Segoe UI', sans-serif;
 
-		--muted: 26.5% 0.02 255;
-		--muted-foreground: 72% 0.014 255;
+		--font-size-xs: 0.75rem;
+		--font-size-sm: 0.875rem;
+		--font-size-base: 1rem;
+		--font-size-lg: 1.125rem;
+		--font-size-xl: 1.25rem;
+		--font-size-2xl: 1.5rem;
+		--font-size-3xl: 1.875rem;
 
-		--card: 21.8% 0.02 255;
-		--card-foreground: 92.4% 0.015 255;
+		--font-line-xs: 1.1;
+		--font-line-sm: 1.35;
+		--font-line-base: 1.5;
+		--font-line-lg: 1.55;
+		--font-line-xl: 1.35;
+		--font-line-2xl: 1.25;
+		--font-line-3xl: 1.2;
 
-		--popover: 19.6% 0.018 255;
-		--popover-foreground: 93.2% 0.014 255;
+		--space-3xs: 0.25rem;
+		--space-2xs: 0.375rem;
+		--space-xs: 0.5rem;
+		--space-sm: 0.75rem;
+		--space-md: 1rem;
+		--space-lg: 1.5rem;
+		--space-xl: 2rem;
+		--space-2xl: 2.5rem;
+		--space-3xl: 3rem;
 
-		--surface: 23.5% 0.022 255;
-		--surface-foreground: 92% 0.015 255;
-		--surface-muted: 27.5% 0.026 255;
-		--surface-muted-foreground: 80% 0.016 255;
-		--surface-accent: 34% 0.045 252;
-		--surface-accent-foreground: 95% 0.015 252;
-
-		--border: 32% 0.022 255;
-		--border-strong: 40% 0.026 255;
-		--input: 30% 0.024 255;
-		--ring: 62.5% 0.2 254;
-
-		--primary: 62.5% 0.2 254;
-		--primary-foreground: 98% 0.02 252;
-
-		--secondary: 55% 0.13 202;
-		--secondary-foreground: 97% 0.02 205;
-
-		--accent: 68% 0.19 210;
-		--accent-foreground: 98% 0.018 210;
-
-		--success: 63% 0.17 152;
-		--success-foreground: 96% 0.018 150;
-
-		--info: 66% 0.16 232;
-		--info-foreground: 16% 0.02 232;
-
-		--warning: 78% 0.17 95;
-		--warning-foreground: 24% 0.045 95;
-
-		--destructive: 56% 0.22 25;
-		--destructive-foreground: 96% 0.02 18;
-
+		--radius-xs: 0.375rem;
 		--radius-sm: 0.5rem;
 		--radius-md: 0.75rem;
-		--radius-lg: 1.25rem;
+		--radius-lg: 1rem;
+		--radius-xl: 1.5rem;
+		--radius-2xl: 2rem;
+
+		--shadow-sm:
+			0 1px 0 0 oklch(var(--color-border) / 0.4),
+			0 6px 14px -10px oklch(var(--color-border-strong) / 0.6);
+		--shadow-md:
+			0 2px 0 0 oklch(var(--color-border) / 0.35),
+			0 22px 42px -24px oklch(var(--color-border-strong) / 0.65);
+		--shadow-lg:
+			0 3px 0 0 oklch(var(--color-border) / 0.3),
+			0 38px 60px -32px oklch(var(--color-border-strong) / 0.7);
+
+		--duration-swift: 120ms;
+		--duration-default: 200ms;
+		--duration-gentle: 320ms;
+		--easing-snappy: cubic-bezier(0.38, 0.7, 0.22, 1);
+		--easing-relaxed: cubic-bezier(0.16, 1, 0.3, 1);
+
+		--z-base: 0;
+		--z-header: 20;
+		--z-overlay: 30;
+		--z-popover: 40;
+
+		--color-neutral-0: 0% 0 0;
+		--color-neutral-50: 96% 0.012 255;
+		--color-neutral-100: 92% 0.014 255;
+		--color-neutral-200: 86% 0.016 255;
+		--color-neutral-300: 78% 0.018 255;
+		--color-neutral-400: 68% 0.02 255;
+		--color-neutral-500: 58% 0.022 255;
+		--color-neutral-600: 46% 0.022 255;
+		--color-neutral-700: 36% 0.02 255;
+		--color-neutral-800: 28% 0.018 255;
+		--color-neutral-850: 24% 0.017 255;
+		--color-neutral-900: 21% 0.016 255;
+		--color-neutral-950: 15% 0.015 255;
+
+		--color-accent-50: 95% 0.032 232;
+		--color-accent-100: 88% 0.05 232;
+		--color-accent-200: 80% 0.08 232;
+		--color-accent-300: 72% 0.12 232;
+		--color-accent-400: 64% 0.16 232;
+		--color-accent-500: 58% 0.18 232;
+		--color-accent-600: 50% 0.18 232;
+		--color-accent-700: 43% 0.16 232;
+		--color-accent-800: 34% 0.14 232;
+		--color-accent-900: 28% 0.12 232;
+
+		--color-primary: 62% 0.19 232;
+		--color-on-primary: 97% 0.015 230;
+		--color-success: 63% 0.16 152;
+		--color-on-success: 95% 0.02 150;
+		--color-warning: 78% 0.17 95;
+		--color-on-warning: 24% 0.05 95;
+		--color-danger: 56% 0.22 25;
+		--color-on-danger: 96% 0.02 15;
+
+		--color-background: var(--color-neutral-950);
+		--color-foreground: var(--color-neutral-50);
+		--color-surface: var(--color-neutral-900);
+		--color-surface-raised: var(--color-neutral-850, 24% 0.02 255);
+		--color-surface-subdued: var(--color-neutral-800);
+		--color-muted: var(--color-neutral-700);
+		--color-on-muted: var(--color-neutral-200);
+		--color-border: var(--color-neutral-700);
+		--color-border-strong: var(--color-neutral-600);
+		--color-input: var(--color-neutral-800);
+		--color-ring: var(--color-accent-500);
+		--color-focus: var(--color-accent-300);
+
+		--size-header: 4.5rem;
+	}
+
+	[data-theme='light'] {
+		color-scheme: light;
+
+		--color-neutral-50: 99% 0.007 255;
+		--color-neutral-100: 98% 0.01 255;
+		--color-neutral-200: 94% 0.012 255;
+		--color-neutral-300: 88% 0.014 255;
+		--color-neutral-400: 78% 0.016 255;
+		--color-neutral-500: 70% 0.018 255;
+		--color-neutral-600: 58% 0.016 255;
+		--color-neutral-700: 46% 0.015 255;
+		--color-neutral-800: 34% 0.014 255;
+		--color-neutral-900: 26% 0.012 255;
+		--color-neutral-950: 14% 0.01 255;
+
+		--color-background: var(--color-neutral-50);
+		--color-foreground: var(--color-neutral-900);
+		--color-surface: var(--color-neutral-0, 100% 0 0);
+		--color-surface-raised: var(--color-neutral-100);
+		--color-surface-subdued: var(--color-neutral-200);
+		--color-muted: var(--color-neutral-200);
+		--color-on-muted: var(--color-neutral-800);
+		--color-border: var(--color-neutral-300);
+		--color-border-strong: var(--color-neutral-400);
+		--color-input: var(--color-neutral-0, 100% 0 0);
 	}
 
 	* {
-		border-color: oklch(var(--border) / 0.65);
+		border-color: oklch(var(--color-border) / 0.65);
 	}
 
 	body {
 		min-height: 100vh;
-		background: oklch(var(--background));
-		color: oklch(var(--foreground));
-		font-family:
-			'Inter Variable',
-			'Inter',
-			ui-sans-serif,
-			system-ui,
-			-apple-system,
-			BlinkMacSystemFont,
-			'Segoe UI',
-			sans-serif;
+		background: oklch(var(--color-background));
+		color: oklch(var(--color-foreground));
+		font-family: var(--font-sans);
 		font-feature-settings: 'ss01', 'cv05', 'cv11';
 		letter-spacing: -0.01em;
 	}
@@ -86,8 +163,8 @@
 	}
 
 	::selection {
-		background: oklch(var(--primary) / 0.2);
-		color: oklch(var(--primary-foreground));
+		background: oklch(var(--color-primary) / 0.2);
+		color: oklch(var(--color-on-primary));
 	}
 
 	:focus-visible {
@@ -96,40 +173,20 @@
 }
 
 @layer utilities {
-	.surface {
-		background: oklch(var(--surface));
-		color: oklch(var(--surface-foreground));
+	.scrollbar-elevated {
+		scrollbar-color: oklch(var(--color-border) / 0.6) transparent;
 	}
 
-	.surface-muted {
-		background: oklch(var(--surface-muted));
-		color: oklch(var(--surface-muted-foreground));
-	}
-
-	.surface-accent {
-		background: oklch(var(--surface-accent));
-		color: oklch(var(--surface-accent-foreground));
-	}
-
-	.card-grid {
-		display: grid;
-		gap: 1.5rem;
-	}
-
-	.marketplace-scrollbar {
-		scrollbar-color: oklch(var(--border) / 0.6) oklch(var(--surface));
-	}
-
-	.marketplace-scrollbar::-webkit-scrollbar {
+	.scrollbar-elevated::-webkit-scrollbar {
 		width: 8px;
 	}
 
-	.marketplace-scrollbar::-webkit-scrollbar-track {
+	.scrollbar-elevated::-webkit-scrollbar-track {
 		background: transparent;
 	}
 
-	.marketplace-scrollbar::-webkit-scrollbar-thumb {
-		background: oklch(var(--border) / 0.65);
+	.scrollbar-elevated::-webkit-scrollbar-thumb {
+		background: oklch(var(--color-border) / 0.65);
 		border-radius: 999px;
 	}
 }

--- a/src/lib/components/chat/ChatList.svelte
+++ b/src/lib/components/chat/ChatList.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+	import { get } from 'svelte/store';
+	import { communityMessages, pushCommunityMessage, rainPot } from '$lib/stores/homepage';
+	import { Button, ScrollArea, Textarea } from '$lib/components/ui';
+	import { cn } from '$lib/utils';
+	import { CloudRain, MessageCircle, Send, Users } from 'lucide-svelte';
+
+	type Props = {
+		class?: string;
+	};
+
+	const props = $props<Props>();
+	const className = $derived(props.class ?? '');
+
+	let messages = $state(get(communityMessages));
+	let pot = $state(get(rainPot));
+	let value = $state('');
+
+	$effect(() => {
+		const unsubscribe = communityMessages.subscribe((next) => {
+			messages = next;
+		});
+		return unsubscribe;
+	});
+
+	$effect(() => {
+		const unsubscribe = rainPot.subscribe((next) => {
+			pot = next;
+		});
+		return unsubscribe;
+	});
+
+	const sendMessage = () => {
+		const trimmed = value.trim();
+		if (!trimmed) return;
+		pushCommunityMessage({ username: 'Guest', message: trimmed });
+		value = '';
+	};
+
+	const handleSubmit = (event: SubmitEvent) => {
+		event.preventDefault();
+		sendMessage();
+	};
+
+	const handleKey = (event: KeyboardEvent) => {
+		if (event.key === 'Enter' && !event.shiftKey) {
+			event.preventDefault();
+			sendMessage();
+		}
+	};
+
+	const handleInput = (event: Event) => {
+		const target = event.target as HTMLTextAreaElement;
+		value = target.value;
+	};
+</script>
+
+<section
+	class={cn('gap-lg flex min-h-0 flex-1 flex-col', className)}
+	aria-labelledby="community-chat-title"
+>
+	<header class="gap-md flex items-center justify-between">
+		<span class="bg-primary/15 text-primary flex h-12 w-12 items-center justify-center rounded-xl">
+			<MessageCircle class="h-5 w-5" aria-hidden="true" />
+		</span>
+		<div class="flex flex-1 flex-col">
+			<h2 id="community-chat-title" class="text-base font-semibold">Community chat</h2>
+			<p class="text-muted-foreground text-xs">Live pulls, rain updates and support pings.</p>
+		</div>
+		<slot name="header-action" />
+	</header>
+
+	<div class="border-border/60 bg-surface-subdued/80 p-md shadow-elevated-sm rounded-xl border">
+		<div class="gap-md flex items-center">
+			<span
+				class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-lg border"
+			>
+				<CloudRain class="h-4 w-4" aria-hidden="true" />
+			</span>
+			<div class="flex flex-1 flex-col">
+				<p class="text-muted-foreground text-xs font-medium tracking-[0.3em] uppercase">Rain pot</p>
+				<p class="text-foreground text-lg font-semibold">{pot.total}</p>
+			</div>
+		</div>
+		<div
+			class="mt-sm text-muted-foreground flex items-center justify-between text-[11px] font-medium tracking-[0.3em] uppercase"
+		>
+			<span class="flex items-center gap-2">
+				<Users class="h-3.5 w-3.5" aria-hidden="true" />
+				{pot.contributors} queued
+			</span>
+			<span>Ends in {pot.endsIn}</span>
+		</div>
+	</div>
+
+	<ScrollArea class="min-h-0 flex-1" viewportClass="flex flex-col gap-sm pr-1">
+		{#each messages as message (message.id)}
+			<article
+				class="border-border/50 bg-surface-subdued/70 p-md rounded-lg border text-sm shadow-none"
+			>
+				<header
+					class="gap-xs text-muted-foreground mb-1 flex flex-wrap items-center justify-between text-xs"
+				>
+					<div class="gap-xs flex items-center">
+						<span class="text-foreground font-semibold">{message.username}</span>
+						{#if message.badge}
+							<span
+								class="bg-primary/15 text-primary rounded-full px-2 py-0.5 text-[10px] tracking-[0.3em] uppercase"
+							>
+								{message.badge}
+							</span>
+						{/if}
+					</div>
+					<span>{message.timestamp}</span>
+				</header>
+				<p class="text-foreground/90 leading-relaxed">{message.message}</p>
+			</article>
+		{/each}
+	</ScrollArea>
+
+	<form class="gap-sm pt-sm mt-auto flex items-end" onsubmit={handleSubmit}>
+		<div class="flex-1">
+			<label for="chat-composer" class="sr-only">Write a message</label>
+			<Textarea
+				id="chat-composer"
+				{value}
+				rows={2}
+				oninput={handleInput}
+				onkeydown={handleKey}
+				placeholder="Drop a message…"
+				class="h-full min-h-[3.25rem] resize-none"
+			/>
+		</div>
+		<Button type="submit" size="icon" class="h-12 w-12 rounded-lg">
+			<Send class="h-4 w-4" aria-hidden="true" />
+			<span class="sr-only">Send message</span>
+		</Button>
+	</form>
+</section>

--- a/src/lib/components/home/CommunityRail.svelte
+++ b/src/lib/components/home/CommunityRail.svelte
@@ -93,7 +93,7 @@
 	</section>
 
 	<div class="mt-5 flex flex-1 flex-col overflow-hidden">
-		<div class="marketplace-scrollbar flex-1 space-y-3 overflow-y-auto pr-2">
+		<div class="scrollbar-elevated flex-1 space-y-3 overflow-y-auto pr-2">
 			{#each messages as message (message.id)}
 				<article
 					class="border-border/40 bg-surface/50 shadow-marketplace-sm rounded-2xl border px-4 py-3 text-sm"

--- a/src/lib/components/home/GameCard.svelte
+++ b/src/lib/components/home/GameCard.svelte
@@ -1,119 +1,77 @@
-﻿<script lang="ts">
+<script lang="ts">
 	type Props = {
 		title: string;
 		subtitle?: string;
 		vendor?: string;
-		image: string; // background css
+		image: string;
 		href?: string;
 	};
 
-	const p: Props = $props();
-	const title = $derived(p.title);
-	const subtitle = $derived(p.subtitle ?? '');
-	const vendor = $derived(p.vendor ?? '');
-	const image = $derived(p.image);
-	const href = $derived(p.href);
+	const props = $props<Props>();
+	const title = $derived(props.title);
+	const subtitle = $derived(props.subtitle ?? '');
+	const vendor = $derived(props.vendor ?? '');
+	const image = $derived(props.image);
+	const href = $derived(props.href);
 </script>
 
 {#if href}
 	<a
 		{href}
-		class="group focus-visible:ring-ring/60 block rounded-[22px] focus:outline-none focus-visible:ring-2"
+		class="group focus-visible:ring-ring focus-visible:ring-offset-background block focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 	>
 		<div
-			class="duration-accent ease-market-ease relative flex h-full flex-col justify-end overflow-hidden rounded-[22px] bg-cover bg-center transition-all hover:-translate-y-1"
+			class="border-border/50 bg-surface-subdued/80 p-md duration-default ease-snappy relative flex h-full flex-col justify-end overflow-hidden rounded-xl border transition-transform group-hover:-translate-y-1"
 			style={`background:${image}`}
 		>
-			<!-- Gradient Frame -->
 			<div
-				class="duration-accent ease-market-ease from-accent/20 to-accent/10 absolute inset-0 rounded-[22px] bg-gradient-to-br via-transparent opacity-0 transition-opacity group-hover:opacity-100"
+				class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent"
+				aria-hidden="true"
 			></div>
-
-			<!-- Spotlight Effect -->
-			<div
-				class="duration-accent ease-market-ease from-foreground/10 absolute inset-0 rounded-[22px] bg-gradient-to-br via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100"
-			></div>
-
-			<!-- Neon Border Glow -->
-			<div
-				class="duration-accent ease-market-ease ring-accent/30 group-hover:ring-accent/60 absolute inset-0 rounded-[22px] opacity-0 ring-1 transition-opacity group-hover:opacity-100"
-			></div>
-
-			<!-- Shadow Enhancement -->
-			<div
-				class="duration-accent ease-market-ease shadow-marketplace-md group-hover:shadow-marketplace-lg absolute inset-0 rounded-[22px] transition-shadow"
-			></div>
-
-			<!-- Content Overlay -->
-			<div
-				class="from-background/85 via-background/25 pointer-events-none absolute inset-0 bg-gradient-to-t to-transparent"
-			></div>
-
-			<!-- Vendor Tag -->
 			{#if vendor}
-				<div class="absolute top-4 left-4 z-10">
-					<div
-						class="border-accent/30 bg-surface-accent/90 text-surface-accent-foreground rounded-full border px-3 py-1 text-xs font-bold tracking-wider uppercase backdrop-blur-sm"
+				<div class="left-md top-md absolute">
+					<span
+						class="border-primary/30 bg-primary/20 px-sm text-primary rounded-full border py-[0.2rem] text-xs font-medium tracking-[0.25em] uppercase"
 					>
 						{vendor}
-					</div>
+					</span>
 				</div>
 			{/if}
-
-			<!-- CTA Chip -->
-			<div
-				class="duration-accent ease-market-ease absolute top-4 right-4 z-10 translate-y-2 opacity-0 transition-all group-hover:translate-y-0 group-hover:opacity-100"
-			>
-				<div
-					class="bg-accent text-accent-foreground shadow-marketplace-sm rounded-full px-4 py-2 text-xs font-bold tracking-wider uppercase backdrop-blur-sm"
-				>
-					Play Now
-				</div>
-			</div>
-
-			<!-- Card Content -->
-			<div class="relative z-10 p-6">
-				<h4 class="text-foreground mb-1 text-xl leading-tight font-black uppercase drop-shadow-lg">
-					{title}
-				</h4>
+			<div class="space-y-xs relative z-10">
+				<h4 class="text-foreground text-lg font-semibold">{title}</h4>
 				{#if subtitle}
-					<p class="text-foreground/90 text-sm font-medium">
-						{subtitle}
-					</p>
+					<p class="text-foreground/80 text-sm">{subtitle}</p>
 				{/if}
+				<span
+					class="text-primary inline-flex items-center text-xs font-medium transition-opacity group-hover:opacity-100"
+				>
+					Play now
+				</span>
 			</div>
 		</div>
 	</a>
 {:else}
 	<div
-		class="relative flex h-full flex-col justify-end overflow-hidden rounded-[22px] bg-cover bg-center"
+		class="border-border/50 bg-surface-subdued/80 p-md relative flex h-full flex-col justify-end overflow-hidden rounded-xl border"
 		style={`background:${image}`}
 	>
-		<!-- Content Overlay -->
 		<div
-			class="from-background/85 via-background/25 pointer-events-none absolute inset-0 bg-gradient-to-t to-transparent"
+			class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent"
+			aria-hidden="true"
 		></div>
-
-		<!-- Vendor Tag -->
 		{#if vendor}
-			<div class="absolute top-4 left-4 z-10">
-				<div
-					class="border-accent/30 bg-surface-accent/90 text-surface-accent-foreground rounded-full border px-3 py-1 text-xs font-bold tracking-wider uppercase backdrop-blur-sm"
+			<div class="left-md top-md absolute">
+				<span
+					class="border-primary/30 bg-primary/20 px-sm text-primary rounded-full border py-[0.2rem] text-xs font-medium tracking-[0.25em] uppercase"
 				>
 					{vendor}
-				</div>
+				</span>
 			</div>
 		{/if}
-
-		<!-- Card Content -->
-		<div class="relative z-10 p-6">
-			<h4 class="text-foreground mb-1 text-xl leading-tight font-black uppercase drop-shadow-lg">
-				{title}
-			</h4>
+		<div class="space-y-xs relative z-10">
+			<h4 class="text-foreground text-lg font-semibold">{title}</h4>
 			{#if subtitle}
-				<p class="text-foreground/90 text-sm font-medium">
-					{subtitle}
-				</p>
+				<p class="text-foreground/80 text-sm">{subtitle}</p>
 			{/if}
 		</div>
 	</div>

--- a/src/lib/components/home/GameGridSection.svelte
+++ b/src/lib/components/home/GameGridSection.svelte
@@ -22,19 +22,19 @@
 	const actionLabel = $derived(props.actionLabel ?? 'view all');
 </script>
 
-<section class="space-y-6">
-	<div class="flex items-center justify-between">
-		<h3 class="text-2xl font-black tracking-wider text-foreground uppercase drop-shadow-sm">
+<section class="space-y-lg">
+	<div class="gap-sm flex flex-wrap items-center justify-between">
+		<h3 class="text-foreground text-2xl font-semibold">
 			{title}
 		</h3>
 		<a
 			href="/cases"
-			class="group duration-accent ease-market-ease rounded-full border border-accent/30 bg-surface-accent px-6 py-3 text-sm font-bold tracking-wider text-surface-accent-foreground uppercase transition-all hover:border-accent/60 hover:bg-accent hover:text-accent-foreground hover:shadow-marketplace-md"
+			class="border-primary/40 bg-primary/15 px-md py-xs text-primary hover:bg-primary hover:text-primary-foreground rounded-full border text-sm font-medium transition-colors"
 		>
 			{actionLabel}
 		</a>
 	</div>
-	<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+	<div class="gap-md grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
 		{#each items as item (item.id)}
 			<GameCard
 				title={item.title}

--- a/src/lib/components/home/HeroCarousel.svelte
+++ b/src/lib/components/home/HeroCarousel.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { heroPromotions } from '$lib/stores/homepage';
 	import { Button, Badge } from '$lib/components/ui';
+	import { cn } from '$lib/utils';
 	import { ChevronLeft, ChevronRight } from 'lucide-svelte';
 
 	const slides = $derived($heroPromotions);
@@ -41,41 +42,43 @@
 
 {#if slides.length}
 	<section
-		class="border-border/70 bg-surface/70 shadow-marketplace-lg relative overflow-hidden rounded-[32px] border"
+		class="border-border/60 bg-surface-raised/80 shadow-elevated-lg relative overflow-hidden rounded-2xl border"
 	>
 		<div
-			class="relative grid min-h-[420px] gap-10 overflow-hidden lg:grid-cols-[1.2fr,0.8fr]"
-			style={`background:${slides[activeIndex]?.background ?? 'var(--surface)'}`}
+			class="gap-xl relative grid min-h-[420px] overflow-hidden lg:grid-cols-[1.2fr,0.8fr]"
+			style={`background:${slides[activeIndex]?.background ?? 'var(--color-surface)'}`}
 		>
-			<div class="relative flex flex-col justify-between p-8 sm:p-12">
-				<div class="text-foreground space-y-6">
-					<div class="flex flex-wrap items-center gap-3">
+			<div class="p-lg sm:p-xl relative flex flex-col justify-between">
+				<div class="space-y-lg text-foreground">
+					<div class="gap-sm flex flex-wrap items-center">
 						<Badge
 							variant="outline"
-							class="border-border/50 bg-surface/40 text-foreground/80 text-xs tracking-[0.35em] uppercase backdrop-blur-sm"
+							class="border-border/60 bg-surface-subdued/80 px-sm text-muted-foreground rounded-full py-1 text-xs font-medium tracking-[0.3em] uppercase"
 						>
 							{slides[activeIndex].tag}
 						</Badge>
-						<span class="text-foreground/70 text-xs sm:text-sm">{slides[activeIndex].subtitle}</span
+						<span class="text-muted-foreground text-xs sm:text-sm"
+							>{slides[activeIndex].subtitle}</span
 						>
 					</div>
-					<div class="space-y-4">
+					<div class="space-y-sm">
 						<h1 class="text-3xl leading-tight font-semibold sm:text-4xl lg:text-5xl">
 							{slides[activeIndex].title}
 						</h1>
-						<p class="text-foreground/80 max-w-2xl text-sm leading-relaxed sm:text-base">
+						<p class="text-foreground/85 max-w-2xl text-sm leading-relaxed sm:text-base">
 							{slides[activeIndex].description}
 						</p>
 					</div>
-					<div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+					<div class="gap-sm flex flex-col sm:flex-row sm:flex-wrap">
 						{#each slides[activeIndex].ctas as cta}
 							<Button
 								variant={cta.variant ?? 'default'}
-								class={`${
+								class={cn(
+									'w-full sm:w-auto',
 									cta.variant === 'outline'
-										? 'border-border/60 text-foreground hover:bg-surface/40 bg-transparent'
-										: 'bg-card text-card-foreground hover:bg-card/90'
-								} w-full sm:w-auto`}
+										? 'border-border/60 text-foreground hover:bg-surface-subdued/70 bg-transparent'
+										: 'bg-primary text-primary-foreground hover:bg-primary/85'
+								)}
 							>
 								{cta.label}
 							</Button>
@@ -84,27 +87,29 @@
 				</div>
 
 				<div
-					class="border-border/40 bg-surface/60 text-foreground/80 grid gap-4 rounded-3xl border p-6 backdrop-blur"
+					class="border-border/50 bg-surface-subdued/80 p-md shadow-elevated-sm rounded-xl border"
 				>
-					<div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+					<div class="gap-sm grid grid-cols-1 sm:grid-cols-3">
 						{#each slides[activeIndex].stats as stat}
-							<div class="border-border/30 bg-surface/40 rounded-2xl border px-4 py-3 text-center">
-								<p class="text-muted-foreground text-[11px] tracking-[0.3em] uppercase">
+							<div class="border-border/40 bg-surface/80 px-sm py-sm rounded-lg border text-center">
+								<p class="text-muted-foreground text-[11px] font-medium tracking-[0.3em] uppercase">
 									{stat.label}
 								</p>
-								<p class="mt-1 text-lg font-semibold">{stat.value}</p>
+								<p class="mt-xs text-lg font-semibold">{stat.value}</p>
 							</div>
 						{/each}
 					</div>
 				</div>
 			</div>
 
-			<aside class="border-border/40 relative hidden h-full flex-col gap-4 border-l p-6 lg:flex">
-				<div class="text-foreground/80 flex items-center justify-between">
-					<p class="text-xs tracking-[0.35em] uppercase">Now trending</p>
-					<div class="flex gap-2">
+			<aside class="gap-md border-border/50 p-lg relative hidden h-full flex-col border-l lg:flex">
+				<div
+					class="text-muted-foreground flex items-center justify-between text-xs font-medium tracking-[0.3em] uppercase"
+				>
+					<p>Now trending</p>
+					<div class="gap-xs flex">
 						<button
-							class="border-border/50 text-muted-foreground hover:border-border/60 hover:text-foreground focus-visible:ring-primary/40 h-10 w-10 rounded-full border transition focus-visible:ring-2 focus-visible:outline-none"
+							class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 							type="button"
 							onclick={() => step(-1)}
 							aria-label="Previous slide"
@@ -112,7 +117,7 @@
 							<ChevronLeft class="h-4 w-4" />
 						</button>
 						<button
-							class="border-border/50 text-muted-foreground hover:border-border/60 hover:text-foreground focus-visible:ring-primary/40 h-10 w-10 rounded-full border transition focus-visible:ring-2 focus-visible:outline-none"
+							class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 							type="button"
 							onclick={() => step(1)}
 							aria-label="Next slide"
@@ -121,56 +126,61 @@
 						</button>
 					</div>
 				</div>
-				<div class="marketplace-scrollbar flex-1 space-y-3 overflow-y-auto pr-1">
+				<div class="scrollbar-elevated space-y-sm flex-1 overflow-y-auto pr-1">
 					{#each slides as slide, index}
 						<button
 							type="button"
-							class={`w-full rounded-2xl border px-4 py-3 text-left transition ${
+							class={cn(
+								'px-md py-sm w-full rounded-lg border text-left text-sm transition',
 								index === activeIndex
-									? 'border-border/50 bg-surface/40 text-foreground shadow-marketplace-sm'
-									: 'bg-surface/30 text-muted-foreground hover:border-border/40 hover:text-foreground border-transparent'
-							}`}
+									? 'border-border/60 bg-surface-subdued/80 text-foreground shadow-elevated-sm'
+									: 'text-muted-foreground hover:border-border/40 hover:bg-surface-subdued/50 hover:text-foreground border-transparent bg-transparent'
+							)}
 							onclick={() => goTo(index)}
 						>
-							<p class="text-[11px] tracking-[0.3em] uppercase">{slide.tag}</p>
-							<p class="mt-2 text-sm font-semibold">{slide.title}</p>
+							<p class="text-muted-foreground text-[11px] tracking-[0.3em] uppercase">
+								{slide.tag}
+							</p>
+							<p class="mt-xs text-foreground font-semibold">{slide.title}</p>
 							<p class="text-muted-foreground text-xs">{slide.subtitle}</p>
 						</button>
 					{/each}
 				</div>
-				<div class="flex items-center justify-center gap-2">
+				<div class="gap-xs flex items-center justify-center">
 					{#each slides as _, index}
 						<span
-							class={`h-1.5 rounded-full transition-all ${
+							class={cn(
+								'h-1.5 rounded-full transition-all',
 								index === activeIndex ? 'bg-foreground w-8' : 'bg-foreground/40 w-3'
-							}`}
+							)}
 						/>
 					{/each}
 				</div>
 			</aside>
 
 			<div
-				class="absolute inset-x-0 bottom-0 flex items-center justify-between gap-2 p-5 lg:hidden"
+				class="gap-sm p-md absolute inset-x-0 bottom-0 flex items-center justify-between lg:hidden"
 			>
 				<button
-					class="border-border/50 text-muted-foreground hover:border-border/60 hover:text-foreground focus-visible:ring-primary/40 h-10 w-10 rounded-full border transition focus-visible:ring-2 focus-visible:outline-none"
+					class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 					type="button"
 					onclick={() => step(-1)}
 					aria-label="Previous slide"
 				>
 					<ChevronLeft class="h-4 w-4" />
 				</button>
-				<div class="flex flex-1 justify-center gap-2">
+				<div class="gap-xs flex flex-1 justify-center">
 					{#each slides as _, index}
 						<span
-							class={`h-1.5 rounded-full transition-all ${
+							class={cn(
+								'h-1.5 rounded-full transition-all',
 								index === activeIndex ? 'bg-foreground w-8' : 'bg-foreground/40 w-3'
-							}`}
+							)}
 						/>
 					{/each}
 				</div>
 				<button
-					class="border-border/50 text-muted-foreground hover:border-border/60 hover:text-foreground focus-visible:ring-primary/40 h-10 w-10 rounded-full border transition focus-visible:ring-2 focus-visible:outline-none"
+					class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 					type="button"
 					onclick={() => step(1)}
 					aria-label="Next slide"

--- a/src/lib/components/home/HomeHero.svelte
+++ b/src/lib/components/home/HomeHero.svelte
@@ -137,7 +137,7 @@
 					</div>
 				</div>
 
-				<div class="marketplace-scrollbar grid flex-1 gap-3 overflow-y-auto pr-1">
+				<div class="scrollbar-elevated grid flex-1 gap-3 overflow-y-auto pr-1">
 					{#each promotions as promo, index}
 						<button
 							type="button"

--- a/src/lib/components/home/HorizontalScroller.svelte
+++ b/src/lib/components/home/HorizontalScroller.svelte
@@ -45,7 +45,7 @@
 		</Button>
 	</div>
 
-	<div class="marketplace-scrollbar -mx-1 flex snap-x gap-4 overflow-x-auto px-1 pb-1">
+	<div class="scrollbar-elevated -mx-1 flex snap-x gap-4 overflow-x-auto px-1 pb-1">
 		{#each items as item}
 			<article
 				class="border-border/40 text-foreground shadow-marketplace-md hover:shadow-marketplace-lg shrink-0 basis-[88%] snap-start rounded-[28px] border bg-cover bg-center bg-no-repeat p-6 transition duration-300 hover:-translate-y-1 sm:basis-[58%] lg:basis-[38%] xl:basis-[28%]"

--- a/src/lib/components/home/KpiStrip.svelte
+++ b/src/lib/components/home/KpiStrip.svelte
@@ -7,7 +7,7 @@
 <section class="space-y-3">
 	<h2 class="text-lg font-semibold tracking-tight">Live marketplace KPIs</h2>
 	<div
-		class="marketplace-scrollbar -mx-1 flex snap-x gap-3 overflow-x-auto px-1 pb-1 md:grid md:snap-none md:grid-cols-3 md:gap-3 md:overflow-visible md:px-0 md:pb-0"
+		class="scrollbar-elevated -mx-1 flex snap-x gap-3 overflow-x-auto px-1 pb-1 md:grid md:snap-none md:grid-cols-3 md:gap-3 md:overflow-visible md:px-0 md:pb-0"
 	>
 		{#each kpis as kpi}
 			<article

--- a/src/lib/components/home/MarketplaceGrid.svelte
+++ b/src/lib/components/home/MarketplaceGrid.svelte
@@ -20,7 +20,7 @@
 		</Button>
 	</div>
 
-	<div class="marketplace-scrollbar grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+	<div class="scrollbar-elevated grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
 		{#each items as item}
 			<article
 				class="border-border/60 bg-surface/80 hover:border-primary/60 group shadow-marketplace-lg relative flex h-full flex-col overflow-hidden rounded-[28px] border transition duration-300 hover:-translate-y-1"

--- a/src/lib/components/shell/BottomNav.svelte
+++ b/src/lib/components/shell/BottomNav.svelte
@@ -2,17 +2,17 @@
 	import { base } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import { Home, Package, Swords, ArrowUpRight, Briefcase } from 'lucide-svelte';
+	import { Home, Gamepad2, MessageCircle, LifeBuoy, Settings } from 'lucide-svelte';
 	import { cn } from '$lib/utils';
+	import { toggleChat } from '$lib/stores/ui';
 
-	type BottomNavProps = {
+	type Props = {
 		isAuthenticated?: boolean;
 		class?: string;
 	};
 
-	const props = $props<BottomNavProps>();
-	const isAuthenticated = $derived(() => props.isAuthenticated ?? false);
-	const className = $derived(() => props.class ?? '');
+	const props = $props<Props>();
+	const className = $derived(props.class ?? '');
 
 	const pageStore = page;
 	const currentPage = $derived(pageStore);
@@ -20,52 +20,58 @@
 
 	const items = [
 		{ href: '/', label: 'Home', icon: Home },
-		{ href: '/cases', label: 'Cases', icon: Package },
-		{ href: '/battles', label: 'Battles', icon: Swords },
-		{ href: '/upgrader', label: 'Upgrader', icon: ArrowUpRight },
-		{ href: '/inventory', label: 'Inventory', icon: Briefcase }
+		{ href: '/cases', label: 'Games', icon: Gamepad2 },
+		{ action: 'chat', label: 'Chat', icon: MessageCircle },
+		{ href: '/support', label: 'Support', icon: LifeBuoy },
+		{ href: '/settings', label: 'Settings', icon: Settings }
 	] as const;
 
-	const isActiveRoute = (href: string) => currentPath === href;
 	const buildHref = (path: string) => (base ? `${base}${path}` : path);
-	const handleNavigation = (href: string) => {
-		// eslint-disable-next-line svelte/no-navigation-without-resolve
-		goto(buildHref(href));
+	const isActiveRoute = (href?: string) => !!href && currentPath === href;
+
+	const handleNavigation = (item: (typeof items)[number]) => {
+		if (item.action === 'chat') {
+			toggleChat();
+			return;
+		}
+
+		if (item.href) {
+			// eslint-disable-next-line svelte/no-navigation-without-resolve
+			goto(buildHref(item.href));
+		}
 	};
 </script>
 
 <nav
-	aria-label="Mobile"
+	aria-label="Mobile navigation"
 	class={cn(
-		'border-border/70 bg-surface/90 shadow-marketplace-lg flex items-center justify-between gap-1 border-t px-2 py-2 backdrop-blur-xl',
+		'gap-xs border-border/60 bg-surface/95 px-sm py-xs shadow-elevated-sm flex items-center justify-between border-t backdrop-blur',
 		className
 	)}
 >
-	{#each items as item (item.href)}
+	{#each items as item (item.label)}
 		<button
 			type="button"
-			onclick={() => handleNavigation(item.href)}
 			class={cn(
-				'text-muted-foreground focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium tracking-[0.25em] uppercase transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+				'px-xs text-muted-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex flex-1 flex-col items-center gap-1 rounded-lg py-1 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
 				isActiveRoute(item.href)
-					? 'bg-primary/20 text-foreground shadow-marketplace-sm'
-					: 'hover:bg-surface-muted/40 hover:text-foreground'
+					? 'bg-primary/15 text-foreground'
+					: 'hover:bg-surface-subdued/60 hover:text-foreground'
 			)}
-			aria-pressed={isActiveRoute(item.href)}
+			onclick={() => handleNavigation(item)}
+			aria-pressed={item.action === 'chat' ? undefined : isActiveRoute(item.href)}
 		>
 			<span
 				class={cn(
-					'flex h-12 w-full items-center justify-center rounded-xl border border-transparent text-sm',
+					'flex h-11 w-full items-center justify-center rounded-md border border-transparent text-sm transition-colors',
 					isActiveRoute(item.href)
-						? 'border-primary/60 bg-primary/25 text-primary-foreground'
+						? 'border-primary/40 bg-primary/20 text-primary'
 						: 'text-muted-foreground'
 				)}
 			>
-				<item.icon class="h-5 w-5" />
+				<item.icon class="h-5 w-5" aria-hidden="true" />
 			</span>
-			<span class="leading-tight tracking-normal normal-case">
-				{item.href === '/inventory' ? (isAuthenticated ? 'Inventory' : 'Locker') : item.label}
-			</span>
+			<span class="leading-none">{item.label}</span>
 		</button>
 	{/each}
 </nav>

--- a/src/lib/components/shell/ChatDrawer.svelte
+++ b/src/lib/components/shell/ChatDrawer.svelte
@@ -1,165 +1,33 @@
 <script lang="ts">
-	import { get } from 'svelte/store';
 	import { uiStore, closeChat } from '$lib/stores/ui';
-	import {
-		communityMessages,
-		pushCommunityMessage,
-		rainPot,
-		type CommunityMessage,
-		type RainPot
-	} from '$lib/stores/homepage';
-	import { X, Send, MessageCircle, CloudRain, Users } from 'lucide-svelte';
-	import { Button, Sheet, SheetContent } from '$lib/components/ui';
+	import { Sheet, SheetContent } from '$lib/components/ui';
+	import ChatList from '$lib/components/chat/ChatList.svelte';
+	import { X } from 'lucide-svelte';
 
 	const uiState = $derived(uiStore);
 	const chatOpen = $derived(() => uiState.chatOpen);
-
-	let messages = $state<CommunityMessage[]>(get(communityMessages));
-	let currentPot = $state<RainPot>(get(rainPot));
-	let input = $state('');
-
-	$effect(() => {
-		const unsubscribe = communityMessages.subscribe((value) => {
-			messages = value;
-		});
-		return unsubscribe;
-	});
-
-	$effect(() => {
-		const unsubscribe = rainPot.subscribe((value) => {
-			currentPot = value;
-		});
-		return unsubscribe;
-	});
-
-	const sendMessage = () => {
-		const trimmed = input.trim();
-		if (!trimmed) return;
-		pushCommunityMessage({ username: 'Guest', message: trimmed });
-		input = '';
-	};
-
-	const handleSubmit = (event: SubmitEvent) => {
-		event.preventDefault();
-		sendMessage();
-	};
-
-	const handleKey = (event: KeyboardEvent) => {
-		if (event.key === 'Enter' && !event.shiftKey) {
-			event.preventDefault();
-			sendMessage();
-		}
-	};
-
-	const handleInput = (event: Event) => {
-		const target = event.target as HTMLTextAreaElement;
-		input = target.value;
-	};
 </script>
 
 <Sheet open={chatOpen} onOpenChange={(open) => (!open ? closeChat() : undefined)}>
 	<SheetContent
 		side="bottom"
-		class="border-border/40 bg-surface/95 shadow-marketplace-lg max-h-[75vh] w-full translate-y-0 rounded-t-[32px] border px-0 pt-4 pb-[env(safe-area-inset-bottom)] backdrop-blur-xl md:max-w-xl"
+		class="border-border/50 bg-surface/95 pt-md shadow-elevated-lg max-h-[75vh] w-full translate-y-0 rounded-t-2xl border pb-[env(safe-area-inset-bottom)] backdrop-blur md:max-w-xl"
 		labelledby="chat-drawer-title"
 	>
-		<div class="mx-auto flex h-full w-full max-w-lg flex-col gap-4 px-4">
+		<div class="gap-md px-md mx-auto flex h-full w-full max-w-lg flex-col">
 			<div class="bg-border/60 mx-auto h-1.5 w-12 rounded-full" aria-hidden="true"></div>
-			<header class="flex items-start justify-between gap-3">
-				<div class="flex items-center gap-3">
-					<span
-						class="bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-2xl"
+			<ChatList class="flex-1">
+				<svelte:fragment slot="header-action">
+					<button
+						type="button"
+						class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2"
+						onclick={closeChat}
+						aria-label="Close chat"
 					>
-						<MessageCircle class="h-5 w-5" />
-					</span>
-					<div>
-						<h2 id="chat-drawer-title" class="text-base font-semibold">Chat & Rain Pot</h2>
-						<p class="text-muted-foreground text-xs">
-							Stay current with live drops and floor chatter.
-						</p>
-					</div>
-				</div>
-				<button
-					type="button"
-					class="border-border/60 bg-surface-muted/60 text-muted-foreground hover:text-foreground flex h-10 w-10 items-center justify-center rounded-2xl border transition"
-					onclick={closeChat}
-					aria-label="Close chat"
-				>
-					<X class="h-4 w-4" />
-				</button>
-			</header>
-
-			<section
-				class="border-border/40 from-primary/15 via-primary/5 rounded-3xl border bg-gradient-to-br to-transparent p-4 text-sm"
-			>
-				<div class="flex items-center gap-3">
-					<span
-						class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-2xl border"
-					>
-						<CloudRain class="h-4 w-4" />
-					</span>
-					<div>
-						<p class="text-muted-foreground text-[11px] tracking-[0.35em] uppercase">Rain pot</p>
-						<p class="text-lg font-semibold">{currentPot.total}</p>
-					</div>
-				</div>
-				<div
-					class="text-muted-foreground mt-3 flex items-center justify-between text-[11px] tracking-[0.3em] uppercase"
-				>
-					<span class="flex items-center gap-2">
-						<Users class="h-3.5 w-3.5" />
-						{currentPot.contributors} queued
-					</span>
-					<span>Ends in {currentPot.endsIn}</span>
-				</div>
-			</section>
-
-			<div class="marketplace-scrollbar flex-1 space-y-3 overflow-y-auto pr-1">
-				{#each messages as message (message.id)}
-					<article class="border-border/50 bg-surface/70 rounded-2xl border px-4 py-3 text-sm">
-						<div class="text-muted-foreground mb-1 flex items-center justify-between text-xs">
-							<div class="flex items-center gap-2">
-								<span class="text-foreground font-semibold">{message.username}</span>
-								{#if message.badge}
-									<span
-										class={`rounded-full px-2 py-0.5 text-[10px] tracking-[0.3em] uppercase ${
-											message.badge === 'vip'
-												? 'bg-primary/20 text-primary'
-												: message.badge === 'staff'
-													? 'bg-accent/20 text-accent-foreground'
-													: 'bg-secondary/20 text-secondary-foreground'
-										}`}
-									>
-										{message.badge}
-									</span>
-								{/if}
-							</div>
-							<span>{message.timestamp}</span>
-						</div>
-						<p class="text-foreground/90 leading-relaxed">{message.message}</p>
-					</article>
-				{/each}
-			</div>
-
-			<form
-				class="border-border/60 bg-surface-muted/50 flex items-center gap-2 rounded-3xl border p-2"
-				onsubmit={handleSubmit}
-			>
-				<label class="sr-only" for="chat-input-mobile">Message</label>
-				<textarea
-					id="chat-input-mobile"
-					value={input}
-					oninput={handleInput}
-					onkeydown={handleKey}
-					rows={1}
-					placeholder="Drop a message…"
-					class="marketplace-scrollbar max-h-24 flex-1 resize-none border-0 bg-transparent px-2 py-1 text-sm focus:outline-none"
-				></textarea>
-				<Button size="icon" class="h-11 w-11 rounded-2xl" type="submit">
-					<Send class="h-4 w-4" />
-					<span class="sr-only">Send message</span>
-				</Button>
-			</form>
+						<X class="h-4 w-4" aria-hidden="true" />
+					</button>
+				</svelte:fragment>
+			</ChatList>
 		</div>
 	</SheetContent>
 </Sheet>

--- a/src/lib/components/shell/ShellHeader.svelte
+++ b/src/lib/components/shell/ShellHeader.svelte
@@ -1,44 +1,22 @@
-﻿<script lang="ts">
+<script lang="ts">
 	import { page } from '$app/stores';
 	import { base } from '$app/paths';
 	import AuthButton from '$lib/components/AuthButton.svelte';
-	import {
-		DropdownMenu,
-		DropdownMenuContent,
-		DropdownMenuItem,
-		DropdownMenuSeparator,
-		DropdownMenuTrigger,
-		Tabs,
-		TabsList,
-		TabsTrigger,
-		Button
-	} from '$lib/components/ui';
-	import { uiStore, toggleSidebar, type UIState } from '$lib/stores/ui';
+	import { Button } from '$lib/components/ui';
+	import { uiStore, toggleSidebar } from '$lib/stores/ui';
 	import { cn } from '$lib/utils';
-	import {
-		Bell,
-		ChevronDown,
-		Gift,
-		Globe,
-		Menu,
-		Search,
-		Sparkles,
-		Wallet
-	} from 'lucide-svelte';
-	import { createEventDispatcher } from 'svelte';
+	import { Bell, Menu, Search } from 'lucide-svelte';
 
-	type ShellHeaderProps = {
-		promoTicker?: { id: string; label: string; meta: string }[];
+	type TickerItem = { id: string; label: string; meta: string };
+
+	type Props = {
+		promoTicker?: TickerItem[];
 		isAuthenticated?: boolean;
-		user?: {
-			username: string;
-			avatar?: string;
-			totalWagered: number;
-		} | null;
+		user?: { username: string } | null;
 		class?: string;
 	};
 
-	const props: ShellHeaderProps = $props();
+	const props = $props<Props>();
 	const promoTicker = $derived(() => props.promoTicker ?? []);
 	const isAuthenticated = $derived(props.isAuthenticated ?? false);
 	const user = $derived(props.user ?? null);
@@ -46,7 +24,7 @@
 
 	let sidebarOpen = $state(false);
 	$effect(() => {
-		const unsubscribe = uiStore.subscribe(($ui: UIState) => {
+		const unsubscribe = uiStore.subscribe(($ui) => {
 			sidebarOpen = $ui.sidebarOpen;
 		});
 		return unsubscribe;
@@ -64,211 +42,119 @@
 		const pathname = currentPath || '/';
 		if (pathname === '/' || pathname === '') return 'Home';
 		const segments = pathname.split('/').filter(Boolean);
-		if (segments.length === 0) return 'Home';
-		const lastSegment = segments[segments.length - 1];
-		return lastSegment
+		if (!segments.length) return 'Home';
+		const last = segments.at(-1) ?? 'Home';
+		return last
 			.split('-')
 			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
 			.join(' ');
 	});
 
 	const homeHref = base ? `${base}/` : '/';
-	const dispatch = createEventDispatcher<{ search: string }>();
-	let searchValue = $state('');
-
-	const handleSearch = (event: SubmitEvent) => {
-		event.preventDefault();
-		dispatch('search', searchValue.trim());
-	};
-
-	const handleSearchInput = (event: Event) => {
-		const target = event.target as HTMLInputElement;
-		searchValue = target.value;
-	};
-
-	const primaryNav = [
-		{ id: 'home', label: 'Home', href: '/' },
-		{ id: 'leaderboard', label: 'Leaderboard', href: '/leaderboard' },
-		{ id: 'clan', label: 'Clan', href: '/clan' }
-	] as const;
-
-	const categoryTabs = [
-		{ id: 'live', label: 'Live' },
-		{ id: 'slots', label: 'Slots' },
-		{ id: 'tournaments', label: 'Tournaments' }
-	] as const;
-
-	let activeCategory = $state(categoryTabs[0]?.id ?? 'live');
-
-	const walletBalance = $derived(() => (user?.totalWagered ?? 0) / 2 + 1561);
 </script>
 
 <header
 	class={cn(
-		'relative z-30 border-b border-border/40 bg-surface/90 shadow-marketplace-sm backdrop-blur-xl',
+		'border-border/60 bg-surface/90 flex h-[var(--size-header)] items-center border-b px-4 backdrop-blur sm:px-6 lg:px-8',
 		className
 	)}
-	style="--shell-header-height: 72px"
+	aria-label="Application shell header"
 >
-	<!-- Gradient Bridge Effect -->
-	<div class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent"></div>
-	<div class="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-surface-accent/10 to-transparent"></div>
-
-	<!-- Mobile Header -->
-	<div class="flex h-[var(--shell-header-height)] items-center justify-between px-4 md:hidden">
-		<div class="flex items-center gap-3">
-			<button
-				type="button"
-				class="group duration-accent ease-market-ease flex h-10 w-10 items-center justify-center rounded-xl border border-border/50 bg-surface-muted/70 text-muted-foreground transition-all hover:border-primary/40 hover:bg-surface-muted hover:text-foreground hover:shadow-marketplace-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
-				onclick={toggleSidebar}
-				aria-expanded={sidebarOpen}
-				aria-label="Open navigation"
-			>
-				<Menu class="h-4 w-4 transition-transform group-hover:scale-110" />
-			</button>
-			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-			<a href={homeHref} class="flex items-center gap-2">
+	<div class="gap-md flex w-full items-center justify-between lg:hidden">
+		<button
+			type="button"
+			class="border-border/60 bg-surface-subdued/70 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2"
+			onclick={toggleSidebar}
+			aria-label="Open navigation"
+			aria-expanded={sidebarOpen}
+		>
+			<Menu class="h-4 w-4" aria-hidden="true" />
+		</button>
+		<div class="gap-sm flex items-center">
+			<a href={homeHref} class="gap-xs text-foreground flex items-center text-sm font-semibold">
 				<span
-					class="flex h-8 w-8 items-center justify-center rounded-lg border border-primary/50 bg-primary/15 text-sm font-bold text-primary"
+					class="border-primary/40 bg-primary/15 text-primary flex h-8 w-8 items-center justify-center rounded-md border"
 				>
 					TR
 				</span>
-				<span class="text-sm font-bold text-foreground">TopRoll</span>
+				{pageTitle()}
 			</a>
 		</div>
-		<h1 class="text-sm font-bold text-foreground">{pageTitle()}</h1>
-		<div class="flex items-center gap-2">
+		<div class="gap-xs flex items-center">
 			<button
 				type="button"
-				class="group duration-accent ease-market-ease flex h-10 w-10 items-center justify-center rounded-xl border border-border/50 bg-surface-muted/70 text-muted-foreground transition-all hover:border-primary/40 hover:bg-surface-muted hover:text-foreground hover:shadow-marketplace-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2"
 				aria-label="Search"
 			>
-				<Search class="h-4 w-4 transition-transform group-hover:scale-110" />
+				<Search class="h-4 w-4" aria-hidden="true" />
 			</button>
 			<button
 				type="button"
-				class="group duration-accent ease-market-ease flex h-10 w-10 items-center justify-center rounded-xl border border-border/50 bg-surface-muted/70 text-muted-foreground transition-all hover:border-primary/40 hover:bg-surface-muted hover:text-foreground hover:shadow-marketplace-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2"
 				aria-label="Notifications"
 			>
-				<Bell class="h-4 w-4 transition-transform group-hover:scale-110" />
+				<Bell class="h-4 w-4" aria-hidden="true" />
 			</button>
 		</div>
 	</div>
 
-	<!-- Desktop Header -->
-	<div class="hidden h-[var(--shell-header-height)] items-center gap-6 px-8 md:flex lg:px-10">
-		<div class="flex items-center gap-3">
-			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-			<a href={homeHref} class="flex items-center gap-2">
+	<div class="gap-xl hidden w-full items-center lg:flex">
+		<div class="gap-md flex min-w-0 items-center">
+			<a href={homeHref} class="gap-sm flex items-center text-left">
 				<span
-					class="flex h-10 w-10 items-center justify-center rounded-xl border border-primary/50 bg-primary/15 text-sm font-bold text-primary"
+					class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-lg border text-sm font-semibold"
 				>
 					TR
 				</span>
 				<div class="flex flex-col">
-					<span class="text-base font-bold leading-tight text-foreground">TopRoll</span>
-					<span class="text-xs font-medium text-muted-foreground">CS2 Marketplace</span>
+					<span class="text-foreground text-sm font-semibold">{pageTitle()}</span>
+					<span class="text-muted-foreground text-xs">Stay current with drops and battles</span>
 				</div>
 			</a>
 		</div>
 
-		<!-- Ticker Chips -->
-		<div class="max-w-2xl flex-1">
-			<div
-				class="scrollbar-hide flex items-center gap-2 overflow-x-auto"
-				role="region"
-				aria-label="Live promotions"
-				aria-live="polite"
-			>
-				{#each promoTicker as item (item.id)}
-					<div
-						class="group duration-accent ease-market-ease flex shrink-0 items-center gap-2 rounded-xl border border-border/40 bg-surface-muted/50 px-3 py-2 backdrop-blur-sm transition-all hover:border-primary/30 hover:bg-surface-muted hover:shadow-marketplace-sm"
-					>
-						<div
-							class="flex h-6 w-6 items-center justify-center rounded-lg border border-primary/30 bg-primary/10"
-						>
-							<svelte:component this={getTickerIcon(item.id)} class="h-3 w-3 text-primary" />
-						</div>
-						<div class="flex flex-col">
-							<span class="text-xs leading-tight font-semibold text-foreground">{item.label}</span>
-							<span class="text-[10px] leading-tight text-muted-foreground">{item.meta}</span>
-						</div>
-					</div>
-				{/each}
-			</div>
-		</div>
-
-		<!-- Search & Actions -->
-		<div class="flex items-center gap-4">
-			<form
-				class="duration-accent ease-market-ease flex items-center gap-3 rounded-xl border border-border/50 bg-surface-muted/60 px-4 py-2.5 transition-all focus-within:border-primary/40 focus-within:bg-surface-muted focus-within:shadow-marketplace-sm hover:border-primary/30"
-				onsubmit={handleSearch}
-			>
-				<Search class="h-4 w-4 text-muted-foreground" />
-				<label class="sr-only" for="desktop-search">Search</label>
-				<input
-					id="desktop-search"
-					type="search"
-					placeholder="Search cases, skins, or players"
-					value={searchValue}
-					oninput={handleSearchInput}
-					class="min-w-[200px] flex-1 border-0 bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
-				/>
-			</form>
-
-			<div class="flex items-center gap-2">
-				<button
-					type="button"
-					class="group duration-accent ease-market-ease flex h-10 w-10 items-center justify-center rounded-xl border border-border/50 bg-surface-muted/70 text-muted-foreground transition-all hover:border-primary/40 hover:bg-surface-muted hover:text-foreground hover:shadow-marketplace-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
-					aria-label="Language"
+		{#if promoTicker.length}
+			<div class="flex flex-1 items-center overflow-hidden">
+				<ul
+					class="scrollbar-elevated gap-sm flex w-full overflow-x-auto py-1"
+					aria-label="Live promotions"
 				>
-					<Globe class="h-4 w-4 transition-transform group-hover:scale-110" />
-				</button>
-				<button
-					type="button"
-					class="group duration-accent ease-market-ease flex h-10 w-10 items-center justify-center rounded-xl border border-border/50 bg-surface-muted/70 text-muted-foreground transition-all hover:border-primary/40 hover:bg-surface-muted hover:text-foreground hover:shadow-marketplace-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
-					aria-label="Notifications"
-				>
-					<Bell class="h-4 w-4 transition-transform group-hover:scale-110" />
-				</button>
-
-				{#if isAuthenticated && user}
-					<DropdownMenu>
-						<DropdownMenuTrigger
-							class="group duration-accent ease-market-ease flex items-center gap-3 rounded-xl border border-border/50 bg-surface-muted/70 px-3 py-2 transition-all hover:border-primary/40 hover:bg-surface-muted hover:shadow-marketplace-sm focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
-						>
-							{#if user.avatar}
-								<img src={user.avatar} alt={user.username || 'User'} class="h-8 w-8 rounded-lg object-cover" />
-							{:else}
-								<div class="flex h-8 w-8 items-center justify-center rounded-lg border border-border/50 bg-surface-muted/80 font-semibold text-muted-foreground">
-									{(user.username || 'U').slice(0, 1).toUpperCase()}
-								</div>
-							{/if}
-							<div class="hidden text-left xl:block">
-								<p class="text-sm leading-tight font-semibold text-foreground">{user.username || 'User'}</p>
-								<p class="text-xs text-muted-foreground">Lvl {Math.floor((user.totalWagered || 0) / 1000) + 1}</p>
+					{#each promoTicker as item (item.id)}
+						<li class="shrink-0">
+							<div
+								class="gap-sm border-border/50 bg-surface-subdued/70 px-sm py-xs text-foreground/90 flex items-center rounded-lg border text-xs"
+							>
+								<span class="font-medium">{item.label}</span>
+								<span class="text-muted-foreground">{item.meta}</span>
 							</div>
-							<ChevronDown class="duration-accent h-4 w-4 text-muted-foreground transition group-aria-expanded:rotate-180" />
-						</DropdownMenuTrigger>
-						<DropdownMenuContent class="w-56" align="end">
-							<div class="px-3 pt-2 pb-3 text-sm">
-								<p class="text-xs tracking-[0.3em] text-muted-foreground uppercase">Signed in</p>
-								<p class="font-semibold">{user.username}</p>
-							</div>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem onSelect={() => {}}>Profile</DropdownMenuItem>
-							<DropdownMenuItem onSelect={() => {}}>Inventory</DropdownMenuItem>
-							<DropdownMenuItem onSelect={() => {}}>Account settings</DropdownMenuItem>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem class="text-destructive" onSelect={() => {}}>Sign out</DropdownMenuItem>
-						</DropdownMenuContent>
-					</DropdownMenu>
-				{:else}
-					<form method="POST" action="/api/auth/steam/login">
-						<AuthButton class="duration-accent bg-primary text-primary-foreground shadow-marketplace-sm transition-all hover:bg-primary/90 hover:shadow-marketplace-md" />
-					</form>
-				{/if}
+						</li>
+					{/each}
+				</ul>
 			</div>
+		{/if}
+
+		<div class="gap-sm flex items-center">
+			<button
+				type="button"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background hidden h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2 xl:flex"
+				aria-label="Search"
+			>
+				<Search class="h-4 w-4" aria-hidden="true" />
+			</button>
+			<button
+				type="button"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background hidden h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2 xl:flex"
+				aria-label="Notifications"
+			>
+				<Bell class="h-4 w-4" aria-hidden="true" />
+			</button>
+			{#if isAuthenticated && user}
+				<Button variant="ghost" class="px-md text-foreground h-10 rounded-full text-sm font-medium">
+					{user.username}
+				</Button>
+			{:else}
+				<AuthButton class="whitespace-nowrap" />
+			{/if}
 		</div>
 	</div>
 </header>

--- a/src/lib/components/shell/Sidebar.svelte
+++ b/src/lib/components/shell/Sidebar.svelte
@@ -1,43 +1,35 @@
-﻿<script lang="ts">
+<script lang="ts">
 	import { page } from '$app/stores';
 	import { base } from '$app/paths';
-	import AuthButton from '$lib/components/AuthButton.svelte';
-	import {
-		Home,
-		Package,
-		User,
-		Swords,
-		LogIn,
-		HelpCircle,
-		MessageSquare,
-		Shield,
-		LifeBuoy,
-		ChevronDown,
-		Briefcase
-	} from 'lucide-svelte';
 	import { Button } from '$lib/components/ui';
 	import { cn } from '$lib/utils';
-	import { closeSidebar } from '$lib/stores/ui';
+	import { closeSidebar, toggleChat } from '$lib/stores/ui';
+	import {
+		Gamepad2,
+		Home,
+		LifeBuoy,
+		MessageCircle,
+		Settings,
+		UserCircle2,
+		LogIn
+	} from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 
 	type SidebarUser = {
 		username: string;
-		balance: number;
-		totalWagered: number;
+		balance?: number;
 	};
 
 	const props = $props<{
 		isAuthenticated?: boolean;
 		user?: SidebarUser | null;
 		class?: string;
-		density?: 'default' | 'compact';
 		children?: Snippet;
 	}>();
 
-	const inboundAuthenticated = $derived(props.isAuthenticated ?? false);
+	const isAuthenticated = $derived(props.isAuthenticated ?? false);
 	const inboundUser = $derived(props.user ?? null);
 	const className = $derived(props.class ?? '');
-	const density = $derived(props.density ?? 'default');
 
 	let currentPath = $state('/');
 	$effect(() => {
@@ -48,248 +40,120 @@
 	});
 
 	const navItems = [
-		{ href: '/', icon: Home, label: 'Home' },
-		{ href: '/cases', icon: Package, label: 'Cases' },
-		{ href: '/battles', icon: Swords, label: 'Battles' },
-		{ href: '/inventory', icon: Briefcase, label: 'Inventory' },
-		{ href: '/profile', icon: User, label: 'Profile' }
+		{ label: 'Home', icon: Home, href: '/' },
+		{ label: 'Games', icon: Gamepad2, href: '/cases' },
+		{ label: 'Chat', icon: MessageCircle, action: 'chat' },
+		{ label: 'Support', icon: LifeBuoy, href: '/support' },
+		{ label: 'Settings', icon: Settings, href: '/settings' }
 	] as const;
-
-	const supportItems = [
-		{ href: '/support', icon: MessageSquare, label: 'Support desk' },
-		{ href: '/faq', icon: HelpCircle, label: 'FAQ' },
-		{ href: '/terms', icon: Shield, label: 'Terms' },
-		{ href: '/responsible', icon: LifeBuoy, label: 'Responsible play' }
-	] as const;
-
-	let previewSignedIn = $state(false);
-	let lastInboundAuthenticated: boolean | null = null;
-
-	$effect(() => {
-		const next = inboundAuthenticated;
-		if (lastInboundAuthenticated === null || next !== lastInboundAuthenticated) {
-			previewSignedIn = next;
-			lastInboundAuthenticated = next;
-		}
-	});
-
-	const fallbackUser = {
-		username: 'rainmaker',
-		balance: 1570,
-		totalWagered: 42800
-	} satisfies SidebarUser;
-
-	const normalizeUser = (value: SidebarUser | null) => {
-		const baseUser = value ?? fallbackUser;
-		return {
-			username: baseUser.username,
-			balance: baseUser.balance ?? 0,
-			totalWagered: baseUser.totalWagered ?? 0
-		} satisfies SidebarUser;
-	};
-
-	const activeUser = $derived(previewSignedIn ? normalizeUser(inboundUser) : null);
-
-	const vaultSummary = [
-		{ label: 'Vault', value: '$640.00' },
-		{ label: 'Withdrawable', value: '$930.00' }
-	];
-
-	const togglePreviewState = () => {
-		previewSignedIn = !previewSignedIn;
-	};
-
-	let showBreakdown = $state(false);
-
-	const toggleBreakdown = () => {
-		showBreakdown = !showBreakdown;
-	};
-
-	$effect(() => {
-		if (!activeUser) {
-			showBreakdown = false;
-		}
-	});
-
-	const isActiveRoute = (href: string) => currentPath === href;
 
 	const buildHref = (path: string) => (base ? `${base}${path}` : path);
+	const isActiveRoute = (href?: string) => !!href && currentPath === href;
 
-	let lastPath: string | null = null;
+	const handleNavClick = (item: (typeof navItems)[number]) => {
+		if (item.action === 'chat') {
+			toggleChat();
+			closeSidebar();
+			return;
+		}
 
-	$effect(() => {
-		const nextPath = currentPath;
-		if (lastPath !== nextPath) {
-			lastPath = nextPath;
+		if (item.href) {
 			closeSidebar();
 		}
-	});
+	};
+
+	const formattedBalance = $derived(() =>
+		inboundUser?.balance != null
+			? `$${inboundUser.balance.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+			: '$0.00'
+	);
 </script>
 
 <aside
 	class={cn(
-		'bg-surface/80 border-border/40 shadow-marketplace-lg flex h-full w-full flex-col rounded-[32px] border backdrop-blur-xl',
-		density === 'compact' ? 'gap-3 px-4 py-4' : 'gap-6 px-6 py-6',
+		'gap-lg border-border/60 bg-surface/80 p-lg shadow-elevated-lg flex h-full min-h-0 flex-col rounded-2xl border backdrop-blur',
 		className
 	)}
 >
-	<a href={buildHref('/')} class="flex items-center gap-3">
-		<span
-			class="border-primary/50 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-xl border text-base font-semibold"
+	<a href={buildHref('/')} class="gap-sm flex items-center text-left">
+		<div
+			class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-lg border text-sm font-semibold"
 		>
 			TR
-		</span>
-		<div class="space-y-0.5">
-			<p class="text-sm leading-none font-semibold">TopRoll</p>
-			<p class="text-muted-foreground text-[11px] tracking-[0.35em] uppercase">CS2 Marketplace</p>
+		</div>
+		<div class="flex flex-col">
+			<span class="text-foreground text-sm font-semibold">TopRoll</span>
+			<span class="text-muted-foreground text-xs">Marketplace shell</span>
 		</div>
 	</a>
 
-	<nav class="space-y-2" aria-label="Primary navigation">
-		{#each navItems as item (item.href)}
-			<Button
-				as="a"
-				href={buildHref(item.href)}
-				variant={isActiveRoute(item.href) ? 'secondary' : 'ghost'}
-				class={cn(
-					'group relative h-14 w-full justify-start gap-3 rounded-2xl px-3 text-left text-sm font-semibold transition',
-					isActiveRoute(item.href)
-						? 'border-primary/60 bg-primary/15 text-foreground shadow-marketplace-sm border'
-						: 'text-muted-foreground hover:text-foreground border border-transparent'
-				)}
-				aria-current={isActiveRoute(item.href) ? 'page' : undefined}
-			>
-				<span
+	<nav aria-label="Main" class="flex flex-col gap-1">
+		{#each navItems as item (item.label)}
+			{#if item.href}
+				<a
+					href={buildHref(item.href)}
 					class={cn(
-						'flex h-12 w-12 items-center justify-center rounded-2xl border transition',
+						'group gap-sm px-md flex min-h-12 items-center rounded-lg border border-transparent text-sm font-medium transition-colors',
 						isActiveRoute(item.href)
-							? 'border-primary/50 bg-primary/20 text-primary'
-							: 'border-border/50 bg-surface-muted/60 text-muted-foreground group-hover:text-foreground'
+							? 'bg-primary/15 text-foreground border-primary/40'
+							: 'text-muted-foreground hover:bg-surface-subdued/70 hover:text-foreground'
 					)}
+					aria-current={isActiveRoute(item.href) ? 'page' : undefined}
+					onclick={() => handleNavClick(item)}
 				>
-					<item.icon class="h-4 w-4" />
-				</span>
-				<span class="flex-1">{item.label}</span>
-				{#if isActiveRoute(item.href)}
-					<span class="bg-primary/60 h-2 w-2 rounded-full"></span>
-				{/if}
-			</Button>
+					<span
+						class={cn(
+							'flex h-10 w-10 items-center justify-center rounded-md border border-transparent transition-colors',
+							isActiveRoute(item.href)
+								? 'bg-primary/20 text-primary'
+								: 'bg-surface-subdued/80 text-muted-foreground group-hover:text-foreground'
+						)}
+					>
+						<item.icon class="h-4 w-4" aria-hidden="true" />
+					</span>
+					<span class="flex-1">{item.label}</span>
+				</a>
+			{:else}
+				<button
+					type="button"
+					class="group gap-sm px-md text-muted-foreground hover:bg-surface-subdued/70 hover:text-foreground flex min-h-12 items-center rounded-lg border border-transparent text-left text-sm font-medium transition-colors"
+					onclick={() => handleNavClick(item)}
+				>
+					<span
+						class="bg-surface-subdued/80 text-muted-foreground group-hover:text-foreground flex h-10 w-10 items-center justify-center rounded-md transition-colors"
+					>
+						<item.icon class="h-4 w-4" aria-hidden="true" />
+					</span>
+					<span class="flex-1">{item.label}</span>
+				</button>
+			{/if}
 		{/each}
 	</nav>
 
-	<section class="border-border/40 bg-surface-muted/30 rounded-3xl border p-4">
-		{#if activeUser}
-			<div class="space-y-3">
-				<div class="flex items-start justify-between gap-4">
-					<div class="space-y-1">
-						<p class="text-muted-foreground text-[11px] tracking-[0.35em] uppercase">
-							Total balance
-						</p>
-						<p class="text-[28px] leading-tight font-semibold tracking-tight">
-							${(activeUser?.balance ?? 0).toLocaleString()}
-						</p>
-						<p class="text-muted-foreground text-xs">
-							Lifetime wagered ${(activeUser?.totalWagered ?? 0).toLocaleString()}
-						</p>
-					</div>
-					<Button
-						variant="ghost"
-						size="sm"
-						onclick={togglePreviewState}
-						class="text-muted-foreground hover:text-foreground h-9 rounded-xl px-3 text-[11px] tracking-[0.3em] uppercase"
+	<div class="gap-lg mt-auto flex flex-col">
+		{#if isAuthenticated && inboundUser}
+			<section
+				class="border-border/50 bg-surface-raised/80 p-md shadow-elevated-sm rounded-xl border"
+			>
+				<header class="gap-sm flex items-center">
+					<span
+						class="bg-primary/15 text-primary flex h-10 w-10 items-center justify-center rounded-full"
 					>
-						Hide
-					</Button>
-				</div>
-				<Button
-					variant="ghost"
-					size="sm"
-					onclick={toggleBreakdown}
-					class="text-muted-foreground hover:text-foreground flex w-full items-center justify-between rounded-2xl px-3 py-2 text-[11px] tracking-[0.3em] uppercase"
-				>
-					Balance breakdown
-					<ChevronDown
-						class={cn(
-							'h-4 w-4 transition-transform duration-200',
-							showBreakdown ? 'rotate-180' : ''
-						)}
-					/>
-				</Button>
-				{#if showBreakdown}
-					<div class="grid gap-2 text-sm">
-						{#each vaultSummary as item (item.label)}
-							<div
-								class="border-border/40 bg-surface/70 flex items-center justify-between rounded-2xl border px-3 py-2"
-							>
-								<span class="text-muted-foreground text-xs tracking-[0.3em] uppercase">
-									{item.label}
-								</span>
-								<span class="font-medium">{item.value}</span>
-							</div>
-						{/each}
+						<UserCircle2 class="h-5 w-5" aria-hidden="true" />
+					</span>
+					<div>
+						<p class="text-foreground text-sm font-semibold">{inboundUser.username}</p>
+						<p class="text-muted-foreground text-xs">Balance {formattedBalance}</p>
 					</div>
-				{/if}
-				<div class="grid grid-cols-2 gap-3">
-					<Button variant="secondary" class="h-12 rounded-2xl text-sm font-semibold">Deposit</Button
-					>
-					<Button variant="ghost" class="h-12 rounded-2xl text-sm font-semibold">Withdraw</Button>
-				</div>
-			</div>
+				</header>
+			</section>
 		{:else}
-			<div class="space-y-3">
-				<div class="space-y-1">
-					<p class="text-base leading-snug font-semibold">Sign in with Steam</p>
-					<p class="text-muted-foreground text-sm leading-relaxed">
-						Connect to deposit instantly, track balance, and join premium drops.
-					</p>
-				</div>
-				<form method="POST" action="/api/auth/steam/login" class="w-full">
-					<AuthButton
-						class="bg-primary text-primary-foreground shadow-marketplace-md w-full justify-center gap-2"
-					/>
-				</form>
-				<div class="flex items-center justify-between gap-3">
-					<Button
-						variant="ghost"
-						size="sm"
-						onclick={togglePreviewState}
-						class="text-muted-foreground hover:text-foreground h-9 rounded-xl px-3 text-[11px] tracking-[0.3em] uppercase"
-					>
-						Preview
-					</Button>
-					<Button
-						variant="ghost"
-						class="text-muted-foreground hover:text-foreground h-12 flex-1 gap-2 rounded-2xl text-sm"
-					>
-						<LogIn class="h-4 w-4" />
-						Explore as guest
-					</Button>
-				</div>
-			</div>
+			<Button class="w-full" size="lg">
+				<LogIn class="h-4 w-4" aria-hidden="true" />
+				Sign in
+			</Button>
 		{/if}
-	</section>
 
-	<div class="mt-auto space-y-4">
-		<div class="border-border/40 bg-surface/70 rounded-3xl border p-4">
-			<p class="text-muted-foreground mb-3 text-[11px] tracking-[0.35em] uppercase">Support</p>
-			<div class="grid gap-2">
-				{#each supportItems as item (item.href)}
-					<Button
-						as="a"
-						href={buildHref(item.href)}
-						variant="ghost"
-						size="sm"
-						class="text-muted-foreground hover:text-foreground justify-start gap-3 rounded-2xl px-3 py-2 text-sm"
-					>
-						<span
-							class="border-border/40 bg-surface-muted/40 flex h-9 w-9 items-center justify-center rounded-xl border"
-						>
-							<item.icon class="h-4 w-4" />
-						</span>
-						{item.label}
-					</Button>
-				{/each}
-			</div>
-		</div>
+		<slot />
 	</div>
 </aside>

--- a/src/lib/components/ui/button.svelte
+++ b/src/lib/components/ui/button.svelte
@@ -25,15 +25,13 @@
 
 	const variantClasses: Record<ButtonVariant, string> = {
 		default:
-			'bg-primary text-primary-foreground shadow-marketplace-sm border border-primary/60 hover:bg-primary/90 hover:border-primary/80',
+			'border border-primary/50 bg-primary text-primary-foreground shadow-elevated-sm hover:bg-primary/85',
 		secondary:
-			'bg-secondary text-secondary-foreground border border-secondary/55 shadow-marketplace-sm hover:bg-secondary/90',
-		outline:
-			'border border-border/70 bg-transparent text-foreground hover:border-primary/70 hover:text-primary hover:bg-surface-muted/40',
+			'border border-border/60 bg-surface-subdued text-foreground shadow-elevated-sm hover:bg-surface-subdued/70',
+		outline: 'border border-border/60 bg-transparent text-foreground hover:bg-surface-subdued/60',
 		ghost:
-			'bg-transparent text-muted-foreground hover:text-foreground hover:bg-surface-muted/30 border border-transparent',
-		destructive:
-			'bg-destructive text-destructive-foreground border border-destructive/60 hover:bg-destructive/90'
+			'border border-transparent bg-transparent text-muted-foreground hover:bg-surface-subdued/60 hover:text-foreground',
+		destructive: 'border border-danger/60 bg-danger text-danger-foreground hover:bg-danger/90'
 	};
 
 	const sizeClasses: Record<ButtonSize, string> = {
@@ -48,7 +46,7 @@
 	this={asProp ?? 'button'}
 	type={asProp ? undefined : (type as HTMLButtonElement['type'])}
 	class={cn(
-		'duration-subtle ease-market-ease focus-visible:ring-ring/70 focus-visible:ring-offset-background inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+		'duration-default ease-snappy focus-visible:ring-ring focus-visible:ring-offset-background inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
 		variantClasses[variant],
 		sizeClasses[size],
 		className

--- a/src/lib/components/ui/card.svelte
+++ b/src/lib/components/ui/card.svelte
@@ -6,7 +6,7 @@
 
 <div
 	class={cn(
-		'border-border/60 bg-card text-card-foreground shadow-marketplace-sm duration-subtle ease-market-ease hover:border-border/80 hover:shadow-marketplace-md rounded-lg border transition-colors',
+		'border-border/60 bg-surface-subdued text-foreground shadow-elevated-sm duration-default ease-relaxed hover:border-border/50 hover:shadow-elevated-md rounded-lg border transition-colors',
 		className
 	)}
 >

--- a/src/lib/components/ui/index.ts
+++ b/src/lib/components/ui/index.ts
@@ -22,3 +22,6 @@ export { default as DropdownMenuTrigger } from './dropdown-menu/dropdown-menu-tr
 export { default as DropdownMenuContent } from './dropdown-menu/dropdown-menu-content.svelte';
 export { default as DropdownMenuItem } from './dropdown-menu/dropdown-menu-item.svelte';
 export { default as DropdownMenuSeparator } from './dropdown-menu/dropdown-menu-separator.svelte';
+export { default as Input } from './input.svelte';
+export { default as Textarea } from './textarea.svelte';
+export { default as ScrollArea } from './scroll-area.svelte';

--- a/src/lib/components/ui/input.svelte
+++ b/src/lib/components/ui/input.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		class?: string;
+	} & Record<string, unknown>;
+
+	let { class: className = '', ...rest }: Props = $props();
+</script>
+
+<input
+	class={cn(
+		'bg-surface-subdued text-foreground placeholder:text-muted-foreground/70 ring-offset-background focus-visible:ring-focus border-border/60 duration-default ease-snappy flex h-11 w-full rounded-lg border px-4 py-2 text-sm transition-shadow focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60',
+		className
+	)}
+	{...rest}
+/>

--- a/src/lib/components/ui/navigation/ScrollableTabs.svelte
+++ b/src/lib/components/ui/navigation/ScrollableTabs.svelte
@@ -31,7 +31,7 @@
 	<div
 		class="from-background via-background/60 pointer-events-none absolute inset-y-0 right-0 hidden w-8 bg-gradient-to-l to-transparent xl:block"
 	></div>
-	<div class="marketplace-scrollbar -mx-4 overflow-x-auto px-4 pb-2">
+	<div class="scrollbar-elevated -mx-4 overflow-x-auto px-4 pb-2">
 		<div class="flex gap-2">
 			{#each tabs as tab}
 				<button

--- a/src/lib/components/ui/scroll-area.svelte
+++ b/src/lib/components/ui/scroll-area.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		class?: string;
+		viewportClass?: string;
+	};
+
+	const props = $props<Props>();
+	const className = $derived(props.class ?? '');
+	const viewportClass = $derived(props.viewportClass ?? '');
+</script>
+
+<div class={cn('relative', className)}>
+	<div class={cn('scrollbar-elevated max-h-full overflow-y-auto', viewportClass)}>
+		<slot />
+	</div>
+</div>

--- a/src/lib/components/ui/textarea.svelte
+++ b/src/lib/components/ui/textarea.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		class?: string;
+	} & Record<string, unknown>;
+
+	let { class: className = '', ...rest }: Props = $props();
+</script>
+
+<textarea
+	class={cn(
+		'bg-surface-subdued text-foreground placeholder:text-muted-foreground/70 ring-offset-background focus-visible:ring-focus border-border/60 duration-default ease-snappy flex min-h-[3.25rem] w-full rounded-lg border px-4 py-3 text-sm transition-shadow focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60',
+		className
+	)}
+	{...rest}
+/>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,4 @@
-﻿<script lang="ts">
+<script lang="ts">
 	import '../app.css';
 	import favicon from '$lib/assets/favicon.svg';
 	import ShellHeader from '$lib/components/shell/ShellHeader.svelte';
@@ -6,7 +6,7 @@
 	import SidebarCTA from '$lib/components/shell/SidebarCTA.svelte';
 	import BottomNav from '$lib/components/shell/BottomNav.svelte';
 	import ChatDrawer from '$lib/components/shell/ChatDrawer.svelte';
-	import ChatPanel from '$lib/components/shell/ChatPanel.svelte';
+	import ChatList from '$lib/components/chat/ChatList.svelte';
 	import { MessageCircle } from 'lucide-svelte';
 	import { uiStore, closeSidebar, toggleChat } from '$lib/stores/ui';
 	import { get } from 'svelte/store';
@@ -33,56 +33,63 @@
 </svelte:head>
 
 <div class="bg-background text-foreground">
-	<div
-		class="mx-auto grid min-h-[100dvh] w-full max-w-[1920px] grid-cols-1 gap-4 px-4 pt-4 pb-[92px] sm:px-6 lg:grid-cols-[280px_minmax(0,1fr)_360px] lg:gap-6 lg:px-8 xl:px-10"
-	>
-		<aside class="block">
-			<div class="sticky top-4 flex h-[calc(100dvh-2rem)] flex-col">
+	<div class="mx-auto flex min-h-[100dvh] w-full max-w-[1920px]">
+		<aside class="hidden lg:flex lg:w-[min(320px,24vw)] lg:flex-col lg:px-6 xl:px-8">
+			<div class="top-lg sticky flex h-[calc(100dvh-var(--space-xl))] flex-col">
 				<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="flex-1">
 					<SidebarCTA />
 				</Sidebar>
 			</div>
 		</aside>
 
-		<div
-			class="lg:border-border/50 lg:bg-surface/70 lg:shadow-marketplace-lg relative flex min-h-[100dvh] flex-col rounded-none lg:col-start-2 lg:rounded-[32px] lg:border lg:backdrop-blur"
-		>
-			<div class="sticky top-0 z-30 lg:rounded-t-[32px]">
-				<ShellHeader {promoTicker} isAuthenticated={data.isAuthenticated} user={data.user} />
-			</div>
-			<main
-				class="marketplace-scrollbar flex-1 overflow-y-auto px-1 pt-6 pb-20 sm:px-3 md:px-4 lg:px-8"
-				aria-label="Primary content"
-			>
-				<div class="mx-auto flex w-full max-w-none flex-col gap-10 pb-6 lg:gap-12">
-					{@render children?.()}
-				</div>
-			</main>
-		</div>
+		<div class="flex min-h-[100dvh] flex-1 flex-col lg:pr-6 xl:pr-8">
+			<ShellHeader
+				class="z-header border-border/50 bg-surface/80 sticky top-0 border-b backdrop-blur"
+				{promoTicker}
+				isAuthenticated={data.isAuthenticated}
+				user={data.user}
+			/>
 
-		<aside class="block">
-			<div class="sticky top-4 flex h-[calc(100dvh-2rem)] flex-col">
+			<div
+				class="gap-lg pt-lg flex min-h-0 flex-1 flex-col px-4 pb-[calc(var(--space-xl)+env(safe-area-inset-bottom))] sm:px-6 md:px-8"
+			>
 				<div
-					class="border-border/50 bg-surface/80 shadow-marketplace-lg flex-1 rounded-[32px] border p-6 backdrop-blur-xl"
+					class="gap-lg flex min-h-0 flex-1 flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start"
 				>
-					<ChatPanel />
+					<main aria-label="Primary content" class="flex min-h-0 flex-1 flex-col">
+						<div class="scrollbar-elevated flex-1 overflow-y-auto">
+							<div class="gap-xl pb-2xl mx-auto flex w-full max-w-[1100px] flex-col">
+								{@render children?.()}
+							</div>
+						</div>
+					</main>
+
+					<aside id="chat" class="hidden min-h-0 flex-col lg:flex">
+						<div
+							class="border-border/60 bg-surface-raised/90 p-md shadow-elevated-md sticky top-[calc(var(--size-header)+var(--space-lg))] flex max-h-[calc(100dvh-var(--size-header)-var(--space-xl)*2)] flex-1 rounded-xl border backdrop-blur"
+						>
+							<ChatList />
+						</div>
+					</aside>
 				</div>
 			</div>
-		</aside>
+		</div>
 	</div>
 
 	<BottomNav
 		isAuthenticated={data.isAuthenticated}
-		class="fixed inset-x-0 bottom-0 z-40 border-t pb-[env(safe-area-inset-bottom)] lg:hidden"
+		class="z-header border-border/60 bg-surface/95 shadow-elevated-sm fixed inset-x-0 bottom-0 border-t pb-[max(var(--space-sm),env(safe-area-inset-bottom))] lg:hidden"
 	/>
 
 	<button
 		type="button"
-		class="bg-primary text-primary-foreground shadow-marketplace-lg fixed right-4 bottom-[92px] z-40 flex items-center gap-3 rounded-full px-4 py-3 text-sm font-medium md:right-6 md:bottom-[96px] lg:hidden"
+		class="right-lg z-header gap-sm bg-primary px-md py-sm text-primary-foreground shadow-elevated-md hover:bg-accent-500 focus-visible:ring-ring focus-visible:ring-offset-background fixed bottom-[calc(var(--space-xl)+var(--space-lg))] flex items-center rounded-full text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 lg:hidden"
 		onclick={handleChatToggle}
 		aria-pressed={chatOpen}
 	>
-		<span class="bg-surface/40 flex h-9 w-9 items-center justify-center rounded-full">
+		<span
+			class="bg-surface-subdued text-primary flex h-10 w-10 items-center justify-center rounded-full"
+		>
 			<MessageCircle class="h-4 w-4" />
 		</span>
 		Chat & Rain Pot
@@ -92,12 +99,12 @@
 
 	{#if sidebarOpen}
 		<div
-			class="bg-background/75 fixed inset-0 z-40 backdrop-blur-sm lg:hidden"
+			class="z-overlay bg-background/75 fixed inset-0 backdrop-blur-sm lg:hidden"
 			role="presentation"
 			onclick={handleSidebarClose}
 		></div>
 		<div
-			class="bg-surface/95 shadow-marketplace-lg fixed inset-y-0 left-0 z-50 w-[320px] max-w-[88vw] overflow-y-auto px-6 pt-6 pb-8 backdrop-blur-xl lg:hidden"
+			class="z-popover border-border/60 bg-surface/95 px-lg pt-xl shadow-elevated-lg fixed inset-y-0 left-0 w-[320px] max-w-[88vw] overflow-y-auto border-r pb-[max(var(--space-xl),env(safe-area-inset-bottom))] backdrop-blur lg:hidden"
 		>
 			<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="h-full">
 				<SidebarCTA />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,10 @@
+<svelte:head>
+	<title>Settings • TopRoll</title>
+</svelte:head>
+
+<section class="space-y-md">
+	<h1 class="text-2xl font-semibold">Settings</h1>
+	<p class="text-muted-foreground text-sm">
+		Profile and notification controls will live here in a future release.
+	</p>
+</section>

--- a/src/routes/support/+page.svelte
+++ b/src/routes/support/+page.svelte
@@ -1,0 +1,10 @@
+<svelte:head>
+	<title>Support • TopRoll</title>
+</svelte:head>
+
+<section class="space-y-md">
+	<h1 class="text-2xl font-semibold">Support</h1>
+	<p class="text-muted-foreground text-sm">
+		Our concierge team will be available here soon. In the meantime please reach out via live chat.
+	</p>
+</section>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,110 +1,144 @@
 import type { Config } from 'tailwindcss';
 import defaultTheme from 'tailwindcss/defaultTheme';
 
+const withAlpha = (variable: string) => `oklch(var(${variable}) / <alpha-value>)`;
+
+/**
+ * Design token driven Tailwind theme.
+ * Tokens are expressed as CSS variables in src/app.css and surfaced here for utility classes.
+ */
 const config = {
 	darkMode: ['class'],
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 	theme: {
 		extend: {
 			colors: {
-				background: 'oklch(var(--background) / <alpha-value>)',
-				foreground: 'oklch(var(--foreground) / <alpha-value>)',
-				card: {
-					DEFAULT: 'oklch(var(--card) / <alpha-value>)',
-					foreground: 'oklch(var(--card-foreground) / <alpha-value>)'
-				},
-				popover: {
-					DEFAULT: 'oklch(var(--popover) / <alpha-value>)',
-					foreground: 'oklch(var(--popover-foreground) / <alpha-value>)'
-				},
-				surface: {
-					DEFAULT: 'oklch(var(--surface) / <alpha-value>)',
-					foreground: 'oklch(var(--surface-foreground) / <alpha-value>)',
-					muted: 'oklch(var(--surface-muted) / <alpha-value>)',
-					mutedForeground: 'oklch(var(--surface-muted-foreground) / <alpha-value>)',
-					accent: 'oklch(var(--surface-accent) / <alpha-value>)',
-					accentForeground: 'oklch(var(--surface-accent-foreground) / <alpha-value>)'
-				},
-				muted: {
-					DEFAULT: 'oklch(var(--muted) / <alpha-value>)',
-					foreground: 'oklch(var(--muted-foreground) / <alpha-value>)'
-				},
-				border: {
-					DEFAULT: 'oklch(var(--border) / <alpha-value>)',
-					strong: 'oklch(var(--border-strong) / <alpha-value>)'
-				},
-				input: 'oklch(var(--input) / <alpha-value>)',
-				ring: 'oklch(var(--ring) / <alpha-value>)',
-				primary: {
-					DEFAULT: 'oklch(var(--primary) / <alpha-value>)',
-					foreground: 'oklch(var(--primary-foreground) / <alpha-value>)'
-				},
-				secondary: {
-					DEFAULT: 'oklch(var(--secondary) / <alpha-value>)',
-					foreground: 'oklch(var(--secondary-foreground) / <alpha-value>)'
+				neutral: {
+					0: withAlpha('--color-neutral-0'),
+					50: withAlpha('--color-neutral-50'),
+					100: withAlpha('--color-neutral-100'),
+					200: withAlpha('--color-neutral-200'),
+					300: withAlpha('--color-neutral-300'),
+					400: withAlpha('--color-neutral-400'),
+					500: withAlpha('--color-neutral-500'),
+					600: withAlpha('--color-neutral-600'),
+					700: withAlpha('--color-neutral-700'),
+					800: withAlpha('--color-neutral-800'),
+					900: withAlpha('--color-neutral-900'),
+					950: withAlpha('--color-neutral-950')
 				},
 				accent: {
-					DEFAULT: 'oklch(var(--accent) / <alpha-value>)',
-					foreground: 'oklch(var(--accent-foreground) / <alpha-value>)'
+					50: withAlpha('--color-accent-50'),
+					100: withAlpha('--color-accent-100'),
+					200: withAlpha('--color-accent-200'),
+					300: withAlpha('--color-accent-300'),
+					400: withAlpha('--color-accent-400'),
+					500: withAlpha('--color-accent-500'),
+					600: withAlpha('--color-accent-600'),
+					700: withAlpha('--color-accent-700'),
+					800: withAlpha('--color-accent-800'),
+					900: withAlpha('--color-accent-900')
 				},
-				destructive: {
-					DEFAULT: 'oklch(var(--destructive) / <alpha-value>)',
-					foreground: 'oklch(var(--destructive-foreground) / <alpha-value>)'
+				primary: {
+					DEFAULT: withAlpha('--color-primary'),
+					foreground: withAlpha('--color-on-primary')
 				},
 				success: {
-					DEFAULT: 'oklch(var(--success) / <alpha-value>)',
-					foreground: 'oklch(var(--success-foreground) / <alpha-value>)'
-				},
-				info: {
-					DEFAULT: 'oklch(var(--info) / <alpha-value>)',
-					foreground: 'oklch(var(--info-foreground) / <alpha-value>)'
+					DEFAULT: withAlpha('--color-success'),
+					foreground: withAlpha('--color-on-success')
 				},
 				warning: {
-					DEFAULT: 'oklch(var(--warning) / <alpha-value>)',
-					foreground: 'oklch(var(--warning-foreground) / <alpha-value>)'
-				}
+					DEFAULT: withAlpha('--color-warning'),
+					foreground: withAlpha('--color-on-warning')
+				},
+				danger: {
+					DEFAULT: withAlpha('--color-danger'),
+					foreground: withAlpha('--color-on-danger')
+				},
+				background: withAlpha('--color-background'),
+				foreground: withAlpha('--color-foreground'),
+				muted: {
+					DEFAULT: withAlpha('--color-muted'),
+					foreground: withAlpha('--color-on-muted')
+				},
+				surface: {
+					DEFAULT: withAlpha('--color-surface'),
+					foreground: withAlpha('--color-on-surface'),
+					raised: withAlpha('--color-surface-raised'),
+					subdued: withAlpha('--color-surface-subdued')
+				},
+				border: {
+					DEFAULT: withAlpha('--color-border'),
+					strong: withAlpha('--color-border-strong')
+				},
+				input: withAlpha('--color-input'),
+				ring: withAlpha('--color-ring'),
+				focus: withAlpha('--color-focus')
 			},
 			borderRadius: {
-				lg: 'var(--radius-lg)',
+				xs: 'var(--radius-xs)',
+				sm: 'var(--radius-sm)',
 				md: 'var(--radius-md)',
-				sm: 'var(--radius-sm)'
-			},
-			fontFamily: {
-				sans: ['Inter Variable', ...defaultTheme.fontFamily.sans]
+				lg: 'var(--radius-lg)',
+				xl: 'var(--radius-xl)',
+				'2xl': 'var(--radius-2xl)'
 			},
 			boxShadow: {
-				'marketplace-sm':
-					'0 1px 0 0 oklch(var(--border) / 0.6), 0 6px 16px -8px oklch(var(--border) / 0.45)',
-				'marketplace-md':
-					'0 1px 0 0 oklch(var(--border-strong) / 0.55), 0 14px 32px -20px oklch(var(--border-strong) / 0.7)',
-				'marketplace-lg':
-					'0 2px 0 0 oklch(var(--border-strong) / 0.55), 0 24px 48px -32px oklch(var(--border-strong) / 0.65)'
+				'elevated-sm': 'var(--shadow-sm)',
+				'elevated-md': 'var(--shadow-md)',
+				'elevated-lg': 'var(--shadow-lg)'
+			},
+			fontFamily: {
+				sans: ['var(--font-sans)', ...defaultTheme.fontFamily.sans]
+			},
+			fontSize: {
+				xs: ['var(--font-size-xs)', 'var(--font-line-xs)'],
+				sm: ['var(--font-size-sm)', 'var(--font-line-sm)'],
+				base: ['var(--font-size-base)', 'var(--font-line-base)'],
+				lg: ['var(--font-size-lg)', 'var(--font-line-lg)'],
+				xl: ['var(--font-size-xl)', 'var(--font-line-xl)'],
+				'2xl': ['var(--font-size-2xl)', 'var(--font-line-2xl)'],
+				'3xl': ['var(--font-size-3xl)', 'var(--font-line-3xl)']
 			},
 			spacing: {
-				'18': '4.5rem',
-				'22': '5.5rem'
+				'3xs': 'var(--space-3xs)',
+				'2xs': 'var(--space-2xs)',
+				xs: 'var(--space-xs)',
+				sm: 'var(--space-sm)',
+				md: 'var(--space-md)',
+				lg: 'var(--space-lg)',
+				xl: 'var(--space-xl)',
+				'2xl': 'var(--space-2xl)',
+				'3xl': 'var(--space-3xl)'
+			},
+			zIndex: {
+				base: 'var(--z-base)',
+				header: 'var(--z-header)',
+				overlay: 'var(--z-overlay)',
+				popover: 'var(--z-popover)'
 			},
 			transitionTimingFunction: {
-				'market-ease': 'cubic-bezier(0.32, 0.72, 0, 1)'
+				'ease-snappy': 'var(--easing-snappy)',
+				'ease-relaxed': 'var(--easing-relaxed)'
 			},
 			transitionDuration: {
-				subtle: '150ms',
-				default: '220ms',
-				accent: '280ms'
+				swift: 'var(--duration-swift)',
+				default: 'var(--duration-default)',
+				gentle: 'var(--duration-gentle)'
 			},
 			keyframes: {
 				'fade-in': {
 					'0%': { opacity: '0' },
 					'100%': { opacity: '1' }
 				},
-				'slide-up': {
-					'0%': { transform: 'translateY(12px)', opacity: '0' },
-					'100%': { transform: 'translateY(0)', opacity: '1' }
+				'scale-in': {
+					'0%': { opacity: '0', transform: 'scale(0.96)' },
+					'100%': { opacity: '1', transform: 'scale(1)' }
 				}
 			},
 			animation: {
-				'fade-in': 'fade-in 200ms ease-out both',
-				'slide-up': 'slide-up 220ms cubic-bezier(0.32, 0.72, 0, 1) both'
+				'fade-in': 'fade-in var(--duration-default) ease-out both',
+				'scale-in': 'scale-in var(--duration-gentle) var(--easing-relaxed) both'
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- replace ad-hoc palette with design tokens surfaced through Tailwind and app-level CSS variables
- rebuild the shell layout to use the new sidebar, header, chat list, and responsive bottom nav patterns
- add shared input/textarea/scroll-area primitives plus support and settings placeholder routes

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors in unrelated routes)*
- npm run test:unit -- --run *(fails: vitest browser runner cannot start Playwright in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf7693d6c83228bc88dabb5e4d6c6