### PR TITLE
Restore TopRoll home styling

### DIFF
--- a/docs/design/theme.md
+++ b/docs/design/theme.md
@@ -1,0 +1,45 @@
+# TopRoll Marketplace Theme Tokens
+
+This document tracks the primitives that power the shell UI. Values map to the CSS custom properties defined in `src/app.css` and surfaced through Tailwind in `tailwind.config.ts`.
+
+## Typography
+
+- `--font-size-xs` → `text-xs`
+- `--font-size-sm` → `text-sm`
+- `--font-size-base` → `text-base`
+- `--font-size-lg` → `text-lg`
+- `--font-size-xl` → `text-xl`
+- `--font-size-2xl` → `text-2xl`
+- `--font-size-3xl` → `text-3xl`
+- `--font-size-4xl` → `text-4xl`
+- `--font-size-5xl` → `text-5xl`
+
+Line height pairs follow the same naming (e.g. `--font-line-4xl`). Use these for hero headlines and marquee stats to keep rhythm tight on dark backgrounds.
+
+## Spacing
+
+Spacing tokens sit on an 8px-friendly scale:
+
+- `--space-3xs` (4px)
+- `--space-2xs` (6px)
+- `--space-xs` (8px)
+- `--space-sm` (12px)
+- `--space-md` (16px)
+- `--space-lg` (24px)
+- `--space-xl` (32px)
+- `--space-2xl` (40px)
+- `--space-3xl` (48px)
+
+## Radii & Elevation
+
+- Radius tokens `--radius-xs` through `--radius-2xl` cover components from pills to full-surface panels.
+- Shadows `--shadow-sm`, `--shadow-md`, `--shadow-lg` map to `shadow-elevated-*` utilities for the card stack hierarchy.
+
+## Color Roles
+
+- Background layers: `--color-background`, `--color-surface`, `--color-surface-raised`, `--color-surface-subdued`
+- Foregrounds: `--color-foreground`, `--color-muted`, `--color-on-muted`
+- Accent & status: `--color-primary`, `--color-accent-*`, `--color-success`, `--color-warning`, `--color-danger`
+- Structure: `--color-border`, `--color-border-strong`, `--color-input`, `--color-ring`
+
+Blend gradients with `oklch(var(--color-primary) / opacity)` or `--color-accent-*` values to stay within the approved blues/purples palette.

--- a/src/app.css
+++ b/src/app.css
@@ -15,6 +15,8 @@
 		--font-size-xl: 1.25rem;
 		--font-size-2xl: 1.5rem;
 		--font-size-3xl: 1.875rem;
+		--font-size-4xl: 2.25rem;
+		--font-size-5xl: 2.75rem;
 
 		--font-line-xs: 1.1;
 		--font-line-sm: 1.35;
@@ -23,6 +25,8 @@
 		--font-line-xl: 1.35;
 		--font-line-2xl: 1.25;
 		--font-line-3xl: 1.2;
+		--font-line-4xl: 1.15;
+		--font-line-5xl: 1.1;
 
 		--space-3xs: 0.25rem;
 		--space-2xs: 0.375rem;
@@ -160,6 +164,11 @@
 	h6 {
 		font-weight: 600;
 		letter-spacing: -0.015em;
+		color: oklch(var(--color-foreground));
+	}
+
+	p {
+		letter-spacing: -0.005em;
 	}
 
 	::selection {

--- a/src/lib/components/chat/ChatList.svelte
+++ b/src/lib/components/chat/ChatList.svelte
@@ -56,30 +56,36 @@
 </script>
 
 <section
-	class={cn('gap-lg flex min-h-0 flex-1 flex-col', className)}
+	class={cn('gap-xl flex min-h-0 flex-1 flex-col', className)}
 	aria-labelledby="community-chat-title"
 >
 	<header class="gap-md flex items-center justify-between">
-		<span class="bg-primary/15 text-primary flex h-12 w-12 items-center justify-center rounded-xl">
+		<span class="bg-primary/15 text-primary flex h-12 w-12 items-center justify-center rounded-2xl">
 			<MessageCircle class="h-5 w-5" aria-hidden="true" />
 		</span>
 		<div class="flex flex-1 flex-col">
-			<h2 id="community-chat-title" class="text-base font-semibold">Community chat</h2>
-			<p class="text-muted-foreground text-xs">Live pulls, rain updates and support pings.</p>
+			<h2 id="community-chat-title" class="text-lg font-semibold">Community chat</h2>
+			<p class="text-muted-foreground text-sm leading-relaxed">
+				Live pulls, rain updates and support pings.
+			</p>
 		</div>
 		<slot name="header-action" />
 	</header>
 
-	<div class="border-border/60 bg-surface-subdued/80 p-md shadow-elevated-sm rounded-xl border">
+	<div
+		class="border-border/50 bg-surface/70 p-lg shadow-elevated-sm rounded-2xl border backdrop-blur"
+	>
 		<div class="gap-md flex items-center">
 			<span
-				class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-lg border"
+				class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-xl border"
 			>
 				<CloudRain class="h-4 w-4" aria-hidden="true" />
 			</span>
 			<div class="flex flex-1 flex-col">
-				<p class="text-muted-foreground text-xs font-medium tracking-[0.3em] uppercase">Rain pot</p>
-				<p class="text-foreground text-lg font-semibold">{pot.total}</p>
+				<p class="text-muted-foreground text-[11px] font-medium tracking-[0.3em] uppercase">
+					Rain pot
+				</p>
+				<p class="text-foreground text-2xl font-semibold">{pot.total}</p>
 			</div>
 		</div>
 		<div
@@ -96,7 +102,7 @@
 	<ScrollArea class="min-h-0 flex-1" viewportClass="flex flex-col gap-sm pr-1">
 		{#each messages as message (message.id)}
 			<article
-				class="border-border/50 bg-surface-subdued/70 p-md rounded-lg border text-sm shadow-none"
+				class="border-border/50 bg-surface/70 p-md shadow-elevated-sm rounded-xl border text-sm backdrop-blur"
 			>
 				<header
 					class="gap-xs text-muted-foreground mb-1 flex flex-wrap items-center justify-between text-xs"
@@ -128,10 +134,10 @@
 				oninput={handleInput}
 				onkeydown={handleKey}
 				placeholder="Drop a message…"
-				class="h-full min-h-[3.25rem] resize-none"
+				class="border-border/60 bg-input/80 text-foreground placeholder:text-muted-foreground/70 focus-visible:ring-ring focus-visible:ring-offset-background px-md py-sm h-full min-h-[3.25rem] resize-none rounded-xl border text-sm shadow-none backdrop-blur focus-visible:ring-2 focus-visible:ring-offset-2"
 			/>
 		</div>
-		<Button type="submit" size="icon" class="h-12 w-12 rounded-lg">
+		<Button type="submit" size="icon" class="h-12 w-12 rounded-xl">
 			<Send class="h-4 w-4" aria-hidden="true" />
 			<span class="sr-only">Send message</span>
 		</Button>

--- a/src/lib/components/home/GameCard.svelte
+++ b/src/lib/components/home/GameCard.svelte
@@ -18,61 +18,87 @@
 {#if href}
 	<a
 		{href}
-		class="group focus-visible:ring-ring focus-visible:ring-offset-background block focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+		class="group/card focus-visible:ring-ring focus-visible:ring-offset-background block h-full focus-visible:rounded-2xl focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 	>
 		<div
-			class="border-border/50 bg-surface-subdued/80 p-md duration-default ease-snappy relative flex h-full flex-col justify-end overflow-hidden rounded-xl border transition-transform group-hover:-translate-y-1"
-			style={`background:${image}`}
+			class="card-surface border-border/50 bg-surface/60 p-lg duration-default ease-snappy relative flex h-full min-h-[18.5rem] flex-col justify-between overflow-hidden rounded-2xl border transition-transform group-hover/card:-translate-y-1"
+			style={`--card-background:${image}`}
 		>
-			<div
-				class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent"
-				aria-hidden="true"
-			></div>
 			{#if vendor}
-				<div class="left-md top-md absolute">
+				<div class="left-lg top-lg absolute z-10">
 					<span
-						class="border-primary/30 bg-primary/20 px-sm text-primary rounded-full border py-[0.2rem] text-xs font-medium tracking-[0.25em] uppercase"
+						class="border-primary/40 bg-primary/15 px-sm text-primary rounded-full border py-[0.35rem] text-[11px] font-semibold tracking-[0.3em] uppercase"
 					>
 						{vendor}
 					</span>
 				</div>
 			{/if}
-			<div class="space-y-xs relative z-10">
+			<div class="space-y-sm relative z-10">
 				<h4 class="text-foreground text-lg font-semibold">{title}</h4>
 				{#if subtitle}
-					<p class="text-foreground/80 text-sm">{subtitle}</p>
+					<p class="text-foreground/80 text-sm leading-relaxed">{subtitle}</p>
 				{/if}
 				<span
-					class="text-primary inline-flex items-center text-xs font-medium transition-opacity group-hover:opacity-100"
+					class="text-primary pt-sm relative inline-flex items-center text-sm font-semibold transition-opacity group-hover/card:opacity-100"
 				>
 					Play now
 				</span>
 			</div>
+			<div aria-hidden="true" class="card-overlay"></div>
 		</div>
 	</a>
 {:else}
 	<div
-		class="border-border/50 bg-surface-subdued/80 p-md relative flex h-full flex-col justify-end overflow-hidden rounded-xl border"
-		style={`background:${image}`}
+		class="card-surface border-border/50 bg-surface/60 p-lg relative flex h-full min-h-[18.5rem] flex-col justify-between overflow-hidden rounded-2xl border"
+		style={`--card-background:${image}`}
 	>
-		<div
-			class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent"
-			aria-hidden="true"
-		></div>
 		{#if vendor}
-			<div class="left-md top-md absolute">
+			<div class="left-lg top-lg absolute z-10">
 				<span
-					class="border-primary/30 bg-primary/20 px-sm text-primary rounded-full border py-[0.2rem] text-xs font-medium tracking-[0.25em] uppercase"
+					class="border-primary/40 bg-primary/15 px-sm text-primary rounded-full border py-[0.35rem] text-[11px] font-semibold tracking-[0.3em] uppercase"
 				>
 					{vendor}
 				</span>
 			</div>
 		{/if}
-		<div class="space-y-xs relative z-10">
+		<div class="space-y-sm relative z-10">
 			<h4 class="text-foreground text-lg font-semibold">{title}</h4>
 			{#if subtitle}
-				<p class="text-foreground/80 text-sm">{subtitle}</p>
+				<p class="text-foreground/80 text-sm leading-relaxed">{subtitle}</p>
 			{/if}
 		</div>
+		<div aria-hidden="true" class="card-overlay"></div>
 	</div>
 {/if}
+
+<style lang="postcss">
+	.card-surface {
+		background: var(--card-background);
+		isolation: isolate;
+	}
+
+	.card-overlay {
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		background: linear-gradient(
+			to top,
+			oklch(var(--color-background) / 0.85),
+			oklch(var(--color-background) / 0.2) 45%,
+			transparent
+		);
+		mix-blend-mode: normal;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.group\/card:hover .card-overlay,
+	.group\/card:focus-visible .card-overlay {
+		background: linear-gradient(
+			to top,
+			oklch(var(--color-background) / 0.78),
+			oklch(var(--color-accent-400) / 0.25) 55%,
+			transparent
+		);
+	}
+</style>

--- a/src/lib/components/home/GameGridSection.svelte
+++ b/src/lib/components/home/GameGridSection.svelte
@@ -22,19 +22,19 @@
 	const actionLabel = $derived(props.actionLabel ?? 'view all');
 </script>
 
-<section class="space-y-lg">
+<section class="space-y-xl">
 	<div class="gap-sm flex flex-wrap items-center justify-between">
 		<h3 class="text-foreground text-2xl font-semibold">
 			{title}
 		</h3>
 		<a
 			href="/cases"
-			class="border-primary/40 bg-primary/15 px-md py-xs text-primary hover:bg-primary hover:text-primary-foreground rounded-full border text-sm font-medium transition-colors"
+			class="border-primary/40 bg-primary/15 px-lg py-sm text-primary hover:bg-primary hover:text-primary-foreground focus-visible:ring-ring focus-visible:ring-offset-background rounded-full border text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 		>
 			{actionLabel}
 		</a>
 	</div>
-	<div class="gap-md grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+	<div class="gap-lg grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
 		{#each items as item (item.id)}
 			<GameCard
 				title={item.title}

--- a/src/lib/components/home/HeroCarousel.svelte
+++ b/src/lib/components/home/HeroCarousel.svelte
@@ -42,13 +42,11 @@
 
 {#if slides.length}
 	<section
-		class="border-border/60 bg-surface-raised/80 shadow-elevated-lg relative overflow-hidden rounded-2xl border"
+		class="hero-shell border-border/60 bg-surface-raised/80 shadow-elevated-lg relative overflow-hidden rounded-3xl border"
+		style={`--hero-background:${slides[activeIndex]?.background ?? 'radial-gradient(circle at 20% 20%, oklch(var(--color-accent-400)/0.45), transparent 55%), rgba(15,23,42,0.92)'};`}
 	>
-		<div
-			class="gap-xl relative grid min-h-[420px] overflow-hidden lg:grid-cols-[1.2fr,0.8fr]"
-			style={`background:${slides[activeIndex]?.background ?? 'var(--color-surface)'}`}
-		>
-			<div class="p-lg sm:p-xl relative flex flex-col justify-between">
+		<div class="hero-grid">
+			<div class="hero-primary">
 				<div class="space-y-lg text-foreground">
 					<div class="gap-sm flex flex-wrap items-center">
 						<Badge
@@ -62,10 +60,10 @@
 						>
 					</div>
 					<div class="space-y-sm">
-						<h1 class="text-3xl leading-tight font-semibold sm:text-4xl lg:text-5xl">
+						<h1 class="text-4xl font-semibold sm:text-5xl">
 							{slides[activeIndex].title}
 						</h1>
-						<p class="text-foreground/85 max-w-2xl text-sm leading-relaxed sm:text-base">
+						<p class="text-foreground/85 max-w-2xl text-base leading-relaxed">
 							{slides[activeIndex].description}
 						</p>
 					</div>
@@ -87,29 +85,31 @@
 				</div>
 
 				<div
-					class="border-border/50 bg-surface-subdued/80 p-md shadow-elevated-sm rounded-xl border"
+					class="hero-stats border-border/50 bg-surface/70 p-lg shadow-elevated-sm rounded-2xl border backdrop-blur"
 				>
-					<div class="gap-sm grid grid-cols-1 sm:grid-cols-3">
+					<div
+						class="divide-border/60 grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0"
+					>
 						{#each slides[activeIndex].stats as stat}
-							<div class="border-border/40 bg-surface/80 px-sm py-sm rounded-lg border text-center">
-								<p class="text-muted-foreground text-[11px] font-medium tracking-[0.3em] uppercase">
+							<div class="stat-tile">
+								<p
+									class="text-muted-foreground text-[11px] font-semibold tracking-[0.3em] uppercase"
+								>
 									{stat.label}
 								</p>
-								<p class="mt-xs text-lg font-semibold">{stat.value}</p>
+								<p class="mt-xs text-foreground text-xl font-semibold">{stat.value}</p>
 							</div>
 						{/each}
 					</div>
 				</div>
 			</div>
 
-			<aside class="gap-md border-border/50 p-lg relative hidden h-full flex-col border-l lg:flex">
-				<div
-					class="text-muted-foreground flex items-center justify-between text-xs font-medium tracking-[0.3em] uppercase"
-				>
+			<aside class="hero-rail">
+				<div class="hero-rail__header">
 					<p>Now trending</p>
-					<div class="gap-xs flex">
+					<div class="flex gap-2">
 						<button
-							class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							class="hero-rail__control"
 							type="button"
 							onclick={() => step(-1)}
 							aria-label="Previous slide"
@@ -117,7 +117,7 @@
 							<ChevronLeft class="h-4 w-4" />
 						</button>
 						<button
-							class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							class="hero-rail__control"
 							type="button"
 							onclick={() => step(1)}
 							aria-label="Next slide"
@@ -158,11 +158,9 @@
 				</div>
 			</aside>
 
-			<div
-				class="gap-sm p-md absolute inset-x-0 bottom-0 flex items-center justify-between lg:hidden"
-			>
+			<div class="hero-mobile-controls">
 				<button
-					class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+					class="hero-rail__control"
 					type="button"
 					onclick={() => step(-1)}
 					aria-label="Previous slide"
@@ -180,7 +178,7 @@
 					{/each}
 				</div>
 				<button
-					class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-9 w-9 items-center justify-center rounded-full border transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+					class="hero-rail__control"
 					type="button"
 					onclick={() => step(1)}
 					aria-label="Next slide"
@@ -191,3 +189,139 @@
 		</div>
 	</section>
 {/if}
+
+<style lang="postcss">
+	.hero-shell {
+		position: relative;
+		isolation: isolate;
+	}
+
+	.hero-shell::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: var(--hero-background);
+		z-index: 0;
+	}
+
+	.hero-shell::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		background:
+			radial-gradient(circle at 20% 20%, oklch(var(--color-accent-300) / 0.28), transparent 65%),
+			radial-gradient(circle at 80% 30%, oklch(var(--color-accent-500) / 0.22), transparent 60%),
+			linear-gradient(
+				135deg,
+				oklch(var(--color-background) / 0.92),
+				oklch(var(--color-background) / 0.35)
+			);
+		mix-blend-mode: normal;
+		pointer-events: none;
+	}
+
+	.hero-grid {
+		position: relative;
+		display: grid;
+		min-height: 26rem;
+		gap: var(--space-xl);
+		padding: var(--space-xl);
+		z-index: 1;
+	}
+
+	@media (min-width: 1024px) {
+		.hero-grid {
+			grid-template-columns: 1.25fr 0.75fr;
+		}
+	}
+
+	.hero-primary {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		gap: var(--space-xl);
+	}
+
+	.hero-stats .stat-tile {
+		padding: var(--space-sm) var(--space-md);
+		text-align: left;
+	}
+
+	@media (min-width: 640px) {
+		.hero-stats .stat-tile {
+			text-align: center;
+		}
+	}
+
+	.hero-rail {
+		display: none;
+	}
+
+	@media (min-width: 1024px) {
+		.hero-rail {
+			display: flex;
+			flex-direction: column;
+			gap: var(--space-md);
+			padding: var(--space-lg);
+			border-left: 1px solid oklch(var(--color-border) / 0.6);
+			background: oklch(var(--color-background) / 0.3);
+			backdrop-filter: blur(16px);
+		}
+	}
+
+	.hero-rail__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		color: oklch(var(--color-muted));
+		font-size: var(--font-size-xs);
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.3em;
+	}
+
+	.hero-rail__control {
+		display: inline-flex;
+		height: 2.5rem;
+		width: 2.5rem;
+		align-items: center;
+		justify-content: center;
+		border-radius: 999px;
+		border: 1px solid oklch(var(--color-border) / 0.6);
+		background: oklch(var(--color-surface) / 0.6);
+		color: oklch(var(--color-muted));
+		transition:
+			color var(--duration-default) var(--easing-snappy),
+			border-color var(--duration-default) var(--easing-snappy),
+			background-color var(--duration-default) var(--easing-snappy);
+	}
+
+	.hero-rail__control:hover {
+		color: oklch(var(--color-foreground));
+		border-color: oklch(var(--color-primary) / 0.5);
+	}
+
+	.hero-rail__control:focus-visible {
+		outline: 2px solid oklch(var(--color-ring));
+		outline-offset: 2px;
+	}
+
+	.hero-mobile-controls {
+		position: absolute;
+		inset-inline: 0;
+		bottom: 0;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-sm);
+		padding: var(--space-md);
+		background: linear-gradient(to top, oklch(var(--color-background) / 0.85), transparent);
+	}
+
+	@media (min-width: 1024px) {
+		.hero-mobile-controls {
+			display: none;
+		}
+	}
+</style>

--- a/src/lib/components/shell/ShellHeader.svelte
+++ b/src/lib/components/shell/ShellHeader.svelte
@@ -63,7 +63,7 @@
 	<div class="gap-md flex w-full items-center justify-between lg:hidden">
 		<button
 			type="button"
-			class="border-border/60 bg-surface-subdued/70 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2"
+			class="border-border/60 bg-surface-subdued/70 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-11 w-11 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2"
 			onclick={toggleSidebar}
 			aria-label="Open navigation"
 			aria-expanded={sidebarOpen}
@@ -71,9 +71,9 @@
 			<Menu class="h-4 w-4" aria-hidden="true" />
 		</button>
 		<div class="gap-sm flex items-center">
-			<a href={homeHref} class="gap-xs text-foreground flex items-center text-sm font-semibold">
+			<a href={homeHref} class="gap-sm text-foreground flex items-center text-sm font-semibold">
 				<span
-					class="border-primary/40 bg-primary/15 text-primary flex h-8 w-8 items-center justify-center rounded-md border"
+					class="border-primary/40 bg-primary/15 text-primary flex h-9 w-9 items-center justify-center rounded-lg border"
 				>
 					TR
 				</span>
@@ -83,14 +83,14 @@
 		<div class="gap-xs flex items-center">
 			<button
 				type="button"
-				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-11 w-11 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2"
 				aria-label="Search"
 			>
 				<Search class="h-4 w-4" aria-hidden="true" />
 			</button>
 			<button
 				type="button"
-				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background flex h-11 w-11 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2"
 				aria-label="Notifications"
 			>
 				<Bell class="h-4 w-4" aria-hidden="true" />
@@ -98,11 +98,11 @@
 		</div>
 	</div>
 
-	<div class="gap-xl hidden w-full items-center lg:flex">
+	<div class="gap-2xl hidden w-full items-center lg:flex">
 		<div class="gap-md flex min-w-0 items-center">
 			<a href={homeHref} class="gap-sm flex items-center text-left">
 				<span
-					class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-lg border text-sm font-semibold"
+					class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-xl border text-sm font-semibold"
 				>
 					TR
 				</span>
@@ -136,20 +136,20 @@
 		<div class="gap-sm flex items-center">
 			<button
 				type="button"
-				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background hidden h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2 xl:flex"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background hidden h-11 w-11 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2 xl:flex"
 				aria-label="Search"
 			>
 				<Search class="h-4 w-4" aria-hidden="true" />
 			</button>
 			<button
 				type="button"
-				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background hidden h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:ring-2 focus-visible:ring-offset-2 xl:flex"
+				class="border-border/60 text-muted-foreground hover:text-foreground focus-visible:ring-ring focus-visible:ring-offset-background hidden h-11 w-11 items-center justify-center rounded-xl border transition focus-visible:ring-2 focus-visible:ring-offset-2 xl:flex"
 				aria-label="Notifications"
 			>
 				<Bell class="h-4 w-4" aria-hidden="true" />
 			</button>
 			{#if isAuthenticated && user}
-				<Button variant="ghost" class="px-md text-foreground h-10 rounded-full text-sm font-medium">
+				<Button variant="ghost" class="px-lg text-foreground h-11 rounded-full text-sm font-medium">
 					{user.username}
 				</Button>
 			{:else}

--- a/src/lib/components/shell/Sidebar.svelte
+++ b/src/lib/components/shell/Sidebar.svelte
@@ -71,13 +71,13 @@
 
 <aside
 	class={cn(
-		'gap-lg border-border/60 bg-surface/80 p-lg shadow-elevated-lg flex h-full min-h-0 flex-col rounded-2xl border backdrop-blur',
+		'gap-xl border-border/60 bg-surface/85 p-xl shadow-elevated-lg flex h-full min-h-0 flex-col rounded-2xl border backdrop-blur',
 		className
 	)}
 >
 	<a href={buildHref('/')} class="gap-sm flex items-center text-left">
 		<div
-			class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-lg border text-sm font-semibold"
+			class="border-primary/40 bg-primary/15 text-primary flex h-11 w-11 items-center justify-center rounded-xl border text-sm font-semibold"
 		>
 			TR
 		</div>
@@ -93,7 +93,7 @@
 				<a
 					href={buildHref(item.href)}
 					class={cn(
-						'group gap-sm px-md flex min-h-12 items-center rounded-lg border border-transparent text-sm font-medium transition-colors',
+						'group gap-sm px-md flex min-h-12 items-center rounded-xl border border-transparent text-sm font-semibold transition-colors',
 						isActiveRoute(item.href)
 							? 'bg-primary/15 text-foreground border-primary/40'
 							: 'text-muted-foreground hover:bg-surface-subdued/70 hover:text-foreground'
@@ -103,7 +103,7 @@
 				>
 					<span
 						class={cn(
-							'flex h-10 w-10 items-center justify-center rounded-md border border-transparent transition-colors',
+							'flex h-10 w-10 items-center justify-center rounded-lg border border-transparent transition-colors',
 							isActiveRoute(item.href)
 								? 'bg-primary/20 text-primary'
 								: 'bg-surface-subdued/80 text-muted-foreground group-hover:text-foreground'
@@ -116,11 +116,11 @@
 			{:else}
 				<button
 					type="button"
-					class="group gap-sm px-md text-muted-foreground hover:bg-surface-subdued/70 hover:text-foreground flex min-h-12 items-center rounded-lg border border-transparent text-left text-sm font-medium transition-colors"
+					class="group gap-sm px-md text-muted-foreground hover:bg-surface-subdued/70 hover:text-foreground flex min-h-12 items-center rounded-xl border border-transparent text-left text-sm font-semibold transition-colors"
 					onclick={() => handleNavClick(item)}
 				>
 					<span
-						class="bg-surface-subdued/80 text-muted-foreground group-hover:text-foreground flex h-10 w-10 items-center justify-center rounded-md transition-colors"
+						class="bg-surface-subdued/80 text-muted-foreground group-hover:text-foreground flex h-10 w-10 items-center justify-center rounded-lg transition-colors"
 					>
 						<item.icon class="h-4 w-4" aria-hidden="true" />
 					</span>
@@ -133,7 +133,7 @@
 	<div class="gap-lg mt-auto flex flex-col">
 		{#if isAuthenticated && inboundUser}
 			<section
-				class="border-border/50 bg-surface-raised/80 p-md shadow-elevated-sm rounded-xl border"
+				class="border-border/50 bg-surface-raised/85 p-lg shadow-elevated-sm rounded-2xl border"
 			>
 				<header class="gap-sm flex items-center">
 					<span

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,16 +33,16 @@
 </svelte:head>
 
 <div class="bg-background text-foreground">
-	<div class="mx-auto flex min-h-[100dvh] w-full max-w-[1920px]">
-		<aside class="hidden lg:flex lg:w-[min(320px,24vw)] lg:flex-col lg:px-6 xl:px-8">
-			<div class="top-lg sticky flex h-[calc(100dvh-var(--space-xl))] flex-col">
+	<div class="mx-auto flex min-h-[100dvh] w-full max-w-[1920px] px-4 sm:px-6 lg:px-8">
+		<aside class="lg:pr-lg xl:pr-xl hidden lg:flex lg:w-[min(320px,24vw)] lg:flex-col">
+			<div class="sticky top-[var(--space-xl)] flex h-[calc(100dvh-var(--space-xl)*2)] flex-col">
 				<Sidebar isAuthenticated={data.isAuthenticated} user={data.user} class="flex-1">
 					<SidebarCTA />
 				</Sidebar>
 			</div>
 		</aside>
 
-		<div class="flex min-h-[100dvh] flex-1 flex-col lg:pr-6 xl:pr-8">
+		<div class="lg:pl-lg xl:pl-xl flex min-h-[100dvh] flex-1 flex-col">
 			<ShellHeader
 				class="z-header border-border/50 bg-surface/80 sticky top-0 border-b backdrop-blur"
 				{promoTicker}
@@ -51,14 +51,14 @@
 			/>
 
 			<div
-				class="gap-lg pt-lg flex min-h-0 flex-1 flex-col px-4 pb-[calc(var(--space-xl)+env(safe-area-inset-bottom))] sm:px-6 md:px-8"
+				class="gap-xl pt-xl flex min-h-0 flex-1 flex-col pb-[calc(var(--space-2xl)+env(safe-area-inset-bottom))]"
 			>
 				<div
-					class="gap-lg flex min-h-0 flex-1 flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start"
+					class="gap-xl flex min-h-0 flex-1 flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start"
 				>
 					<main aria-label="Primary content" class="flex min-h-0 flex-1 flex-col">
 						<div class="scrollbar-elevated flex-1 overflow-y-auto">
-							<div class="gap-xl pb-2xl mx-auto flex w-full max-w-[1100px] flex-col">
+							<div class="gap-2xl pb-3xl mx-auto flex w-full max-w-[1100px] flex-col">
 								{@render children?.()}
 							</div>
 						</div>
@@ -66,7 +66,7 @@
 
 					<aside id="chat" class="hidden min-h-0 flex-col lg:flex">
 						<div
-							class="border-border/60 bg-surface-raised/90 p-md shadow-elevated-md sticky top-[calc(var(--size-header)+var(--space-lg))] flex max-h-[calc(100dvh-var(--size-header)-var(--space-xl)*2)] flex-1 rounded-xl border backdrop-blur"
+							class="border-border/60 bg-surface-raised/90 p-lg shadow-elevated-lg sticky top-[calc(var(--size-header)+var(--space-xl))] flex max-h-[calc(100dvh-var(--size-header)-var(--space-2xl)*2)] flex-1 rounded-2xl border backdrop-blur"
 						>
 							<ChatList />
 						</div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -98,7 +98,9 @@ const config = {
 				lg: ['var(--font-size-lg)', 'var(--font-line-lg)'],
 				xl: ['var(--font-size-xl)', 'var(--font-line-xl)'],
 				'2xl': ['var(--font-size-2xl)', 'var(--font-line-2xl)'],
-				'3xl': ['var(--font-size-3xl)', 'var(--font-line-3xl)']
+				'3xl': ['var(--font-size-3xl)', 'var(--font-line-3xl)'],
+				'4xl': ['var(--font-size-4xl)', 'var(--font-line-4xl)'],
+				'5xl': ['var(--font-size-5xl)', 'var(--font-line-5xl)']
 			},
 			spacing: {
 				'3xs': 'var(--space-3xs)',


### PR DESCRIPTION
## Summary
- realign the application shell spacing, header controls, and chat layout with the design token scale
- refresh the hero carousel with palette-driven gradients, typography hierarchy updates, and balanced stat tiles
- tighten featured card, grid, and community chat treatments for consistent elevation, padding, and contrast

## Testing
- pnpm lint *(fails: existing lint violations in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfe3ec8808322ab3de61c55682de6