### PR TITLE
Refine battle UI interactions and centralize toast store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,9 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
-# Paraglide
-src/lib/paraglide
+# Paraglide (auto-generated, keep type shims in repo)
+src/lib/paraglide/*
+!src/lib/paraglide/.gitignore
+!src/lib/paraglide/messages.d.ts
+!src/lib/paraglide/runtime.ts
+!src/lib/paraglide/server.ts

--- a/docs/product/specs/README.md
+++ b/docs/product/specs/README.md
@@ -1,0 +1,11 @@
+# Module Specs Hub
+
+This directory contains module-level PRDs that extend the launch PRD.
+Each spec follows the spec-first workflow outlined in `docs/product/README.md`:
+
+1. Document MVP scope, success criteria, data contracts, and UX flows.
+2. Reference the relevant requirements/tasks that implementation PRs must satisfy.
+3. Link back to the main PRD sections to keep the narrative consistent.
+
+When adding a new module spec, update `docs/product/status.md` and `tasks.md`
+so delivery tracking stays in sync.

--- a/docs/product/specs/community-pots.md
+++ b/docs/product/specs/community-pots.md
@@ -1,0 +1,112 @@
+# Module PRD — Community Pots (P4 Scope)
+
+**Status:** Draft  •  **Phase Link:** [P4 — Core Features](../phases/P4.md)  •  **Parent PRD:** [Launch PRD §D.3](../../PRD.md)
+
+## 1. Objective & Outcomes
+
+Ship a transparent pooled game where users contribute credits into rotating
+pots, watch live ticket reveals, and see provably-fair outcomes with audited
+payouts. Community Pots act as a retention funnel into Case Battles and the
+Marketplace by highlighting high-velocity wins.
+
+### Success Metrics
+- Time-to-fill (TTF) ≤ 90 seconds for 75% of pots during peak hours.
+- Payout accuracy: 100% of pots settle with correct credit transfers.
+- Fraud detection: flag ≥ 95% of suspicious entries before settlement.
+
+## 2. Scope & Non-Goals (MVP)
+
+### In Scope
+- Pot lobby showing active, filling, and completed pots with live credit totals.
+- Entry flow: select pot → choose ticket count → confirm spend.
+- Ticket allocation with per-user cap and anti-collusion checks.
+- Provably-fair commit/reveal: orchestrator stores commit hash, settlement service verifies reveal.
+- Realtime updates for pot totals, entrant roster, and winner announcement.
+- Post-settlement summary modal with hashes, winners, and credit distribution.
+
+### Out of Scope
+- Multi-winner or tiered payout structures (single winner only for MVP).
+- Cross-pot auto-entry or queueing.
+- Cash-out / withdrawal of winnings (handled by wallet later).
+
+## 3. User Stories
+- **As a player**, I can join a pot, see my entries accumulate, and watch the draw in real time.
+- **As a spectator**, I can observe pots filling, cheer, and join before lock.
+- **As compliance**, I can audit the commit/reveal data and pause suspicious pots.
+
+## 4. Functional Requirements
+
+### 4.1 Pot Lifecycle
+- `pots` table stores `id`, `status` (`open`, `locked`, `settling`, `settled`, `cancelled`),
+  `entry_cost`, `max_tickets`, `max_per_user`, `commit_hash`, `reveal_seed`, timestamps.
+- API:
+  - GET `/api/pots` → paginated list with filters `status`, `min_value`, `max_value`.
+  - POST `/api/pots/{id}/join` → reserve tickets; validates balance, per-user limit, RLS.
+  - POST `/api/pots/{id}/lock` → orchestrator transitions to drawing state when filled or timer hits.
+  - POST `/api/pots/{id}/reveal` → settlement service provides reveal seed + signature.
+- Locking triggers commit broadcast and realtime event `pots:{id}:locked`.
+
+### 4.2 Ticket Management
+- `pot_entries` table stores `id`, `pot_id`, `user_id`, `ticket_count`, `credits_spent`, `created_at`.
+- Entries are immutable once pot locks; cancellations only during `open` state.
+- Track per-user totals to enforce `max_per_user` and detect collusion (same IP/device). Logs forwarded to compliance pipeline.
+
+### 4.3 Settlement & Payouts
+- Winner chosen via deterministic hash: `winner_index = HMAC_SHA256(reveal_seed, commit_hash) % total_tickets`.
+- Settlement service credits winner and updates `pots.winner_user_id`, `settled_at`.
+- Realtime event `pots:{id}:settled` broadcasts results and triggers Live Drops entry.
+- Store `settlement_proof` blob linking commit, reveal, orchestrator signature, settlement signature.
+
+### 4.4 UX & Notifications
+- Lobby shows progress bar per pot (`credits_committed / (entry_cost * max_tickets)`).
+- Entry modal pre-fills recommended ticket counts (1, 3, 5) with accessible buttons.
+- Winner modal lists commit hash, reveal seed, fairness verification instructions.
+- Push notifications (webhooks) for large wins (configurable threshold).
+
+### 4.5 Compliance & Moderation
+- Admin API `/api/pots/{id}/pause` to halt entries; reason logged in `pots_audit` table.
+- Guard rails: blocked regions, velocity limits, duplicate device detection.
+- All user actions log to structured events with correlation IDs per ADR.
+
+## 5. Data Model & DTOs
+
+| Table | Key Fields | Notes |
+|-------|------------|-------|
+| `pots` | `id` UUID, `status`, `entry_cost`, `max_tickets`, `max_per_user`, `commit_hash`, `reveal_seed`, `winner_user_id`, timestamps | RLS ensures only orchestrator/service can mutate status beyond join. |
+| `pot_entries` | `id`, `pot_id`, `user_id`, `ticket_count`, `credits_spent`, `ip_hash`, `device_hash`, timestamps | Used for anti-collusion analytics. |
+| `pots_audit` | `id`, `pot_id`, `action`, `actor_id`, `reason`, `metadata`, `created_at` | Append-only log for moderation. |
+
+### DTOs
+- `PotSummary`: `id`, `status`, `entry_cost`, `credits_committed`, `participant_count`, `fill_percent`, `max_tickets`, `max_per_user`, `commit_hash?` (exposed once locked).
+- `PotDetail`: `PotSummary` + entries list (partial for spectators), fairness proofs, winner info.
+- `JoinPotRequest`: `{ pot_id: string, ticket_count: number }`.
+- `RevealPayload`: `{ pot_id: string, reveal_seed: string, settlement_signature: string }`.
+
+## 6. UX Flow
+1. Lobby fetches `/api/pots` server-side and hydrates Svelte stores; subscribes to realtime channel `pots:lobby`.
+2. User opens entry modal, selects ticket count, confirms purchase. UI shows optimistic entry while awaiting server confirmation.
+3. When pot locks, UI transitions to countdown + fairness commit display.
+4. Settlement reveal triggers winner animation and summary modal; losers see CTA to join next pot.
+5. Completed pots move to history tab with accessible transcript of commit/reveal data.
+
+## 7. Dependencies
+- Requires Supabase realtime channels and Postgres functions for commit/reveal locking.
+- Settlement service provides reveal seed + credits transfer.
+- Shared provably-fair utilities with Case Battles (reuse DTOs where possible).
+- Observability pipeline must capture fairness metrics per pot.
+
+## 8. Analytics & Alerts
+- Track events: `pot_joined`, `pot_locked`, `pot_settled`, `pot_cancelled`.
+- Alert on: pot locked > 2 minutes without settlement, duplicate IPs > threshold, reveal mismatch.
+- Dashboard: TTF distribution, churn rate (players joining subsequent pots), fraud flag volume.
+
+## 9. Risks & Open Questions
+- Need final decision on spectator view of entrant list (full vs summarized) for privacy.
+- Collusion detection heuristics may cause false positives; require override UX.
+- Settlement dependency latency—define SLA with settlement service.
+
+## 10. Acceptance Criteria
+- APIs documented here implemented with Supabase schema and RLS.
+- Frontend lobby shows realtime fills, handles locked/settled transitions gracefully.
+- Commit/reveal proofs persisted and exposed for audit with verifiable hash chain.
+- Automated tests cover entry caps, fairness calculations, settlement success/failure paths.

--- a/docs/product/specs/marketplace.md
+++ b/docs/product/specs/marketplace.md
@@ -1,0 +1,106 @@
+# Module PRD — Marketplace (P4 Scope)
+
+**Status:** Draft  •  **Phase Link:** [P4 — Core Features](../phases/P4.md)  •  **Parent PRD:** [Launch PRD §D.2](../../PRD.md)
+
+## 1. Objective & Outcomes
+
+Deliver the first version of the skin Marketplace where authenticated users
+can list CS2 items for credits, browse listings with live valuations, and
+purchase items instantly. The Marketplace must align with the provably-fair
+and compliance guardrails defined in the launch requirements.
+
+### Success Metrics
+- ≥ 85% of attempted listings succeed without manual intervention.
+- Listing-to-purchase conversion ≥ 25% within the first 24h of posting.
+- No more than 0.5% of transactions require manual refunds.
+
+## 2. Scope & Non-Goals (MVP)
+
+### In Scope
+- Browse grid of active listings with rarity, float, price, and freshness badges.
+- Item detail drawer with valuation history and seller metadata.
+- Listing flow: select inventory item → suggested price → confirm listing.
+- Purchase flow: review listing → confirm spend → success/error states.
+- Supabase persistence for listings, transactions, and inventory snapshots.
+- Realtime updates via Supabase channels for new/updated listings.
+- Compliance hooks: soft region gating, trade lock detection, max price limit.
+
+### Out of Scope (Defer)
+- Automated bot fulfillment or escrow withdrawal flows.
+- Auction bidding, counter-offers, or bundle listings.
+- Cross-currency pricing and localized taxation.
+- Creator storefronts or featured slots.
+
+## 3. User Stories
+- **As a seller**, I can list a CS2 item with an auto-suggested fair price and confirm before publishing.
+- **As a buyer**, I can filter and sort listings to find the items I want and purchase instantly.
+- **As operations**, I can pause listings that violate policies and audit listing history.
+
+## 4. Functional Requirements
+
+### 4.1 Listings & Catalog
+- Provide `/api/marketplace/listings` endpoint with pagination, rarity filters, price sorting.
+- Each listing includes: `id`, `item_id`, `user_id`, `ask_price`, `suggested_price`,
+  `rarity`, `float_value`, `wear_tier`, `thumbnail_url`, `created_at`, `expires_at`.
+- Catalog view refreshes server-side every request and subscribes to realtime updates for incremental changes.
+
+### 4.2 Listing Creation
+- Protected POST `/api/marketplace/listings` that validates inventory ownership,
+  verifies trade lock, and enforces price bands (`0.8x` – `1.2x` of valuation).
+- Listing uses valuation snapshot table to prevent race conditions; snapshot TTL 5 minutes.
+- On success, emit Supabase realtime event `marketplace:listings:created` for subscribers.
+
+### 4.3 Purchasing
+- Protected POST `/api/marketplace/purchase` verifying listing availability, buyer balance,
+  and concurrency via `status='available'` row lock.
+- Deduct buyer credits and credit seller via settlement service webhook.
+- Persist transaction record with PF hash for audit.
+- Emit realtime events for `marketplace:listings:fulfilled` and append to Live Drops ticker.
+
+### 4.4 Moderation & Compliance
+- Admin-only PATCH `/api/marketplace/listings/{id}/status` to pause/resume listings.
+- Store `region_blocked` flag derived from user profile settings.
+- Record rejection reasons for compliance audit trail.
+
+## 5. Data Model & DTOs
+
+| Table | Key Fields | Notes |
+|-------|------------|-------|
+| `marketplace_listings` | `id` UUID PK, `user_id` FK → `auth.users`, `item_id`, `valuation_id`, `ask_price`, `status` (`available`, `sold`, `paused`, `expired`), timestamps | RLS: sellers manage own listings; admins can moderate. |
+| `marketplace_transactions` | `id`, `listing_id`, `buyer_id`, `seller_id`, `final_price`, `pf_hash`, `settlement_id`, timestamps | Immutable after completion. |
+| `inventory_snapshots` | `id`, `user_id`, `item_id`, `steam_asset_id`, `valuation`, `float`, `captured_at` | Created during listing flow. |
+
+### DTOs
+- `ListingSummary`: fields above + computed `is_new` (<=15min) and `price_delta` vs valuation.
+- `ListingDetail`: `ListingSummary` + valuation history array, seller rep score, compliance flags.
+- `CreateListingRequest`: `{ item_id: string, ask_price: number }`.
+- `PurchaseRequest`: `{ listing_id: string }`.
+
+## 6. UX & Interaction Notes
+- Grid uses neo-brutalist cards, 3-column desktop / 1-column mobile.
+- Filter bar anchored top with sticky behavior on desktop, collapsible on mobile.
+- Listing drawer slides from right; confirm button uses `variant="neo-primary"` per design system.
+- Loading skeletons mimic card layout; empty state references Community Pots for engagement.
+- Errors surface via toast with actionable copy; forms fully keyboard accessible.
+
+## 7. Dependencies & Integration
+- Requires Steam inventory service for valuation data.
+- Settlement service handles credit transfers; purchase API must call and await response.
+- Live Drops ticker consumes realtime listing fulfillment events.
+- Aligns with ADR-20251003-spec-workflow governance.
+
+## 8. Analytics & Telemetry
+- Track events: `listing_created`, `listing_paused`, `listing_purchased`, `listing_failed`.
+- Include properties: `item_id`, `rarity`, `ask_price`, `valuation_delta`, `region`, `latency_ms`.
+- Expose daily metrics dashboard for ops: volume, GMV, conversion, failure rate.
+
+## 9. Risks & Open Questions
+- Price volatility may require dynamic bands – monitor feedback.
+- Need clear UX for trade-locked items; design iteration TBD.
+- Settlement failure handling: define retry/backoff with settlement service team.
+
+## 10. Acceptance Criteria
+- API endpoints documented above implemented with tests.
+- UI grid matches design system tokens and consumes realtime data.
+- RLS policies enforce seller-only mutations; admin overrides audited.
+- pnpm check/lint/test all green for implementation PRs.

--- a/docs/product/status.md
+++ b/docs/product/status.md
@@ -6,8 +6,16 @@
 | P1 — Architecture & Conventions | ⏳ Not started | ⏸ Pending P0 | TBD | Depends on finalized governance from P0. |
 | P2 — DevEx & CI/CD | ⏳ Not started | ⏸ Pending P0 | TBD | Will extend `.github` workflows defined in P0. |
 | P3 — Observability & Security | ⏳ Not started | ⏸ Pending earlier phases | TBD | Logging schema & correlation middleware required. |
-| P4 — Core Features | ⏳ Not started | ⏸ Pending specs | TBD | Tied to module PRDs (Auth, Pots, Battles, etc.). |
+| P4 — Core Features | 🔄 Drafting | ⏸ Pending specs | TBD | Marketplace & Community Pots module PRDs in progress (see below). |
 | P5 — UX & Accessibility | ⏳ Not started | ⏸ Pending tokens | TBD | Align with `UI_IMPROVEMENT_GUIDE.md` and design system. |
 | P6 — Release & QA | ⏳ Not started | ⏸ Pending earlier phases | TBD | Release checklist, rollback, analytics. |
+
+## Module Spec Index
+
+| Module | Spec | Status | Notes |
+|--------|------|--------|-------|
+| Marketplace | [`docs/product/specs/marketplace.md`](specs/marketplace.md) | 🆕 Draft | Captures listings, purchase APIs, and realtime UX requirements. |
+| Community Pots | [`docs/product/specs/community-pots.md`](specs/community-pots.md) | 🆕 Draft | Defines pot lifecycle, commit/reveal, and anti-collusion controls. |
+| Case Battles | [`docs/CASE_BATTLES_GAME_PLAN_2025.md`](../CASE_BATTLES_GAME_PLAN_2025.md) | ✅ Existing | Remains canonical until module spec migrated. |
 
 Update this table in every spec PR. "Doc Status" reflects the spec readiness (Draft, Ready for Review, Approved). "Implementation Status" tracks code PR progress.

--- a/src/lib/components/CaseOpeningRoulette.svelte
+++ b/src/lib/components/CaseOpeningRoulette.svelte
@@ -51,7 +51,10 @@
 			indicatorRef: !!indicatorRef,
 			gsap: !!gsapInstance
 		});
-		if (!browser || isSpinning || !rouletteRef || !indicatorRef || !gsapInstance) return;
+                if (!browser || isSpinning || !rouletteRef || !indicatorRef || !gsapInstance) return;
+
+                const gsapLocal = gsapInstance;
+                if (!gsapLocal) return;
 
 		console.log('Starting GSAP animation...');
 		isSpinning = true;
@@ -59,7 +62,7 @@
 		winningItem = null;
 
 		// Reset roulette position
-		gsapInstance.set(rouletteRef, { x: 0 });
+                gsapLocal.set(rouletteRef, { x: 0 });
 
 		// Select random winning item
 		const randomIndex = Math.floor(Math.random() * items.length);
@@ -74,7 +77,7 @@
 		const finalPosition = -(items.length * itemWidth + randomIndex * itemWidth - centerOffset);
 
 		// Indicator pulse during spin
-		gsapInstance.to(indicatorRef, {
+                gsapLocal.to(indicatorRef, {
 			scaleY: 1.3,
 			scaleX: 0.8,
 			duration: 0.08,
@@ -84,14 +87,14 @@
 		});
 
 		// Perfect easing timeline
-		const tl = gsapInstance.timeline({
-			onComplete: () => {
-				winningItem = selectedItem;
-				isSpinning = false;
+                const tl = gsapLocal.timeline({
+                        onComplete: () => {
+                                winningItem = selectedItem;
+                                isSpinning = false;
 
-				// Stop indicator animation smoothly
-				gsapInstance.killTweensOf(indicatorRef);
-				gsapInstance.to(indicatorRef, { scaleY: 1, scaleX: 1, duration: 0.2 });
+                                // Stop indicator animation smoothly
+                                gsapLocal.killTweensOf(indicatorRef);
+                                gsapLocal.to(indicatorRef, { scaleY: 1, scaleX: 1, duration: 0.2 });
 
 				// Reveal result with timing
 				setTimeout(() => {
@@ -102,14 +105,14 @@
 		});
 
 		// Phase 1: Fast acceleration
-		tl.to(rouletteRef, {
+                tl.to(rouletteRef, {
 			x: finalPosition + 800,
 			duration: 1.8,
 			ease: 'power2.out'
 		});
 
 		// Phase 2: Perfect deceleration to exact position
-		tl.to(rouletteRef, {
+                tl.to(rouletteRef, {
 			x: finalPosition,
 			duration: 1.5,
 			ease: 'power4.out'

--- a/src/lib/components/ErrorBoundary.svelte
+++ b/src/lib/components/ErrorBoundary.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { AlertTriangle, RefreshCw, Home, Clipboard } from '@lucide/svelte';
-	import {
+        import { onMount } from 'svelte';
+        import type { Snippet } from 'svelte';
+        import { AlertTriangle, RefreshCw, Home, Clipboard } from '@lucide/svelte';
+        import {
 		Button,
 		Card,
 		CardContent,
@@ -50,8 +51,8 @@
 		};
 	});
 
-	const currentError = error || errorDetails;
-	const showError = hasError || !!error;
+        const currentError = $derived(error ?? errorDetails);
+        const showError = $derived(hasError || !!error);
 
 	function handleRetry() {
 		hasError = false;

--- a/src/lib/components/MicroInteractions.svelte
+++ b/src/lib/components/MicroInteractions.svelte
@@ -217,30 +217,30 @@
 	}
 
 	/* Enhanced button states for gaming theme */
-	.gaming-button {
-		position: relative;
-		overflow: hidden;
-		transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-	}
+        :global(.gaming-button) {
+                position: relative;
+                overflow: hidden;
+                transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
 
-	.gaming-button:hover {
-		box-shadow:
-			0 0 20px rgb(from var(--color-primary) r g b / 0.4),
-			0 8px 25px -5px rgb(from var(--color-primary) r g b / 0.2);
-	}
+        :global(.gaming-button:hover) {
+                box-shadow:
+                        0 0 20px rgb(from var(--color-primary) r g b / 0.4),
+                        0 8px 25px -5px rgb(from var(--color-primary) r g b / 0.2);
+        }
 
-	.gaming-button:active {
-		transform: scale(0.98);
-	}
+        :global(.gaming-button:active) {
+                transform: scale(0.98);
+        }
 
-	/* Custom focus states for accessibility */
-	.gaming-button:focus-visible {
-		outline: 2px solid var(--color-primary);
-		outline-offset: 2px;
-		box-shadow:
-			0 0 0 4px rgb(from var(--color-primary) r g b / 0.1),
-			0 0 20px rgb(from var(--color-primary) r g b / 0.4);
-	}
+        /* Custom focus states for accessibility */
+        :global(.gaming-button:focus-visible) {
+                outline: 2px solid var(--color-primary);
+                outline-offset: 2px;
+                box-shadow:
+                        0 0 0 4px rgb(from var(--color-primary) r g b / 0.1),
+                        0 0 20px rgb(from var(--color-primary) r g b / 0.4);
+        }
 
 	/* Loading state animations */
 	@keyframes gaming-pulse {
@@ -255,9 +255,9 @@
 		}
 	}
 
-	.gaming-pulse {
-		animation: gaming-pulse 2s ease-in-out infinite;
-	}
+        :global(.gaming-pulse) {
+                animation: gaming-pulse 2s ease-in-out infinite;
+        }
 
 	/* Success/Error feedback animations */
 	@keyframes success-flash {
@@ -278,37 +278,37 @@
 		}
 	}
 
-	.success-flash {
-		animation: success-flash 0.3s ease-out;
-	}
+        :global(.success-flash) {
+                animation: success-flash 0.3s ease-out;
+        }
 
-	.error-flash {
-		animation: error-flash 0.3s ease-out;
-	}
+        :global(.error-flash) {
+                animation: error-flash 0.3s ease-out;
+        }
 
 	/* Responsive hover effects */
 	@media (hover: none) and (pointer: coarse) {
-		.gaming-button:hover {
-			box-shadow: none;
-		}
+                :global(.gaming-button:hover) {
+                        box-shadow: none;
+                }
 
-		.gaming-button:active {
-			transform: scale(0.95);
-			box-shadow: 0 0 20px rgb(from var(--color-primary) r g b / 0.4);
-		}
+                :global(.gaming-button:active) {
+                        transform: scale(0.95);
+                        box-shadow: 0 0 20px rgb(from var(--color-primary) r g b / 0.4);
+                }
 	}
 
 	/* Reduce motion for accessibility */
 	@media (prefers-reduced-motion: reduce) {
-		.animate-ripple,
-		.float-up,
-		.shake-animation,
-		.gaming-pulse {
+                .animate-ripple,
+                .float-up,
+                .shake-animation,
+                :global(.gaming-pulse) {
 			animation: none !important;
 		}
 
-		.gaming-button {
-			transition: none !important;
-		}
+                :global(.gaming-button) {
+                        transition: none !important;
+                }
 	}
 </style>

--- a/src/lib/components/ProfileCard.svelte
+++ b/src/lib/components/ProfileCard.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 	import type { HTMLAttributes } from 'svelte/elements';
 	import type { UserProfile } from '$lib/types';
-	import {
-		Card,
-		CardContent,
-		CardHeader,
-		CardTitle,
-		CardDescription,
-		Badge
-	} from '$lib/components/ui';
+        import {
+                Card,
+                CardContent,
+                CardHeader,
+                CardTitle,
+                CardDescription,
+                Badge
+        } from '$lib/components/ui';
+        import type { BadgeVariant } from '$lib/components/ui';
 	import { cn } from '$lib/utils';
 
 	interface ProfileCardProps extends HTMLAttributes<HTMLDivElement> {
@@ -31,16 +32,11 @@
 			.join('')
 	);
 
-	const statusVariant = $derived(() => {
-		switch (status) {
-			case 'online':
-				return 'success';
-			case 'away':
-				return 'warning';
-			default:
-				return 'outline';
-		}
-	});
+        const statusVariant = $derived((): BadgeVariant => {
+                if (status === 'online') return 'success';
+                if (status === 'away') return 'warning';
+                return 'outline';
+        });
 </script>
 
 <Card class={cn('border-border/60 bg-surface/70 border', className)} {...restProps}>
@@ -69,9 +65,9 @@
 				<span
 					class="border-background bg-surface-muted/80 absolute -right-1 -bottom-1 flex h-5 w-5 items-center justify-center rounded-full border"
 				>
-					<Badge variant={statusVariant} class="px-2 text-[10px] tracking-wide uppercase"
-						>{status}</Badge
-					>
+                                        <Badge variant={statusVariant()} class="px-2 text-[10px] tracking-wide uppercase">
+                                                {status}
+                                        </Badge>
 				</span>
 			</div>
 			<div class="text-muted-foreground space-y-1 text-sm">

--- a/src/lib/components/SteamMarketplace.svelte
+++ b/src/lib/components/SteamMarketplace.svelte
@@ -60,8 +60,8 @@
 	const rarities = ['All', 'Consumer', 'Industrial', 'Mil-Spec', 'Restricted', 'Classified', 'Covert', 'Contraband'];
 	const types = ['All', 'Knife', 'Glove', 'Rifle', 'Pistol', 'SMG', 'Sniper', 'Shotgun', 'Machinegun', 'Sticker', 'Case'];
 
-	const filteredItems = $derived(() => {
-		let filtered = items;
+        const filteredItems = $derived.by<MarketItem[]>(() => {
+                let filtered = [...items];
 
 		if (searchTerm) {
 			filtered = filtered.filter(item =>
@@ -100,8 +100,32 @@
 			return sortOrder === 'asc' ? comparison : -comparison;
 		});
 
-		return filtered;
-	});
+                return filtered;
+        });
+
+        function handleSearchInput(event: Event) {
+                const target = event.target as HTMLInputElement | null;
+                if (!target) return;
+                onSearch?.(target.value);
+        }
+
+        function handleRarityChange(event: Event) {
+                const target = event.target as HTMLSelectElement | null;
+                if (!target) return;
+                onFilterRarity?.(target.value);
+        }
+
+        function handleTypeChange(event: Event) {
+                const target = event.target as HTMLSelectElement | null;
+                if (!target) return;
+                onFilterType?.(target.value);
+        }
+
+        function handleSortChange(event: Event) {
+                const target = event.target as HTMLSelectElement | null;
+                if (!target) return;
+                onSort?.(target.value, sortOrder);
+        }
 
 	const formatCurrency = (amount: number) => {
 		return new Intl.NumberFormat('en-US', {
@@ -150,7 +174,7 @@
 						placeholder="Search items..."
 						bind:value={searchTerm}
 						class="pl-9 pr-3 py-2 bg-surface/50 border border-border/40 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
-						oninput={(e) => onSearch?.(e.target.value)}
+                                                oninput={handleSearchInput}
 					/>
 				</div>
 
@@ -180,7 +204,7 @@
 			<select
 				class="bg-surface/50 border border-border/40 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
 				value={selectedRarity}
-				onchange={(e) => onFilterRarity?.(e.target.value)}
+                                onchange={handleRarityChange}
 			>
 				{#each rarities as rarity}
 					<option value={rarity}>{rarity}</option>
@@ -190,7 +214,7 @@
 			<select
 				class="bg-surface/50 border border-border/40 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
 				value={selectedType}
-				onchange={(e) => onFilterType?.(e.target.value)}
+                                onchange={handleTypeChange}
 			>
 				{#each types as type}
 					<option value={type}>{type}</option>
@@ -200,7 +224,7 @@
 			<select
 				class="bg-surface/50 border border-border/40 rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
 				value={sortBy}
-				onchange={(e) => onSort?.(e.target.value, sortOrder)}
+                                onchange={handleSortChange}
 			>
 				<option value="popularity">Popularity</option>
 				<option value="price">Price</option>

--- a/src/lib/components/battles/BattleCreateDialog.svelte
+++ b/src/lib/components/battles/BattleCreateDialog.svelte
@@ -202,19 +202,20 @@
 
 {#if open}
 	<!-- Backdrop -->
-	<div
-		class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
-		onclick={handleClose}
+        <div
+                class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+                on:click={handleClose}
 		role="dialog"
 		aria-modal="true"
 		aria-labelledby="dialog-title"
 		aria-describedby="dialog-description"
 	>
 		<!-- Dialog Panel -->
-		<div
-			class="bg-surface border border-border/40 rounded-xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col"
-			onclick={(e) => e.stopPropagation()}
-		>
+                <div
+                        class="bg-surface border border-border/40 rounded-xl shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col"
+                        role="presentation"
+                        on:click|stopPropagation
+                >
 			<!-- Header -->
 			<header class="p-6 border-b border-border/40">
 				<div class="flex items-center justify-between">
@@ -227,10 +228,10 @@
 							Configure your battle settings and select cases
 						</p>
 					</div>
-					<Button
-						variant="ghost"
-						size="icon"
-						onclick={handleClose}
+                                        <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                on:click={handleClose}
 						class="h-8 w-8"
 						aria-label="Close dialog"
 					>

--- a/src/lib/components/battles/BattlePullReel.svelte
+++ b/src/lib/components/battles/BattlePullReel.svelte
@@ -4,7 +4,8 @@
 	import { Card, CardContent } from '$lib/components/ui/card';
 	import { Sparkles, Trophy, Play, RefreshCw, Gift } from '@lucide/svelte';
 	import { onMount } from 'svelte';
-	import { BattleAnimations, createAnimation, createStaggerAnimation } from '$lib/utils/animations';
+        import { BattleAnimations, animations } from '$lib/utils/animations';
+        import { CheckCircle, Clock } from '@lucide/svelte';
 	import type { Battle, BattlePull, CaseItem } from '$lib/types';
 
 	// Props using Svelte 5 syntax
@@ -31,12 +32,12 @@
 	let itemElements: HTMLElement[] = [];
 
 	// Animation lifecycle
-	onMount(() => {
-		// Set up entrance animations for static elements
-		if (reelContainer) {
-			BattleAnimations.slideInUp(reelContainer, { delay: 0.2 });
-		}
-	});
+        onMount(() => {
+                // Set up entrance animations for static elements
+                if (reelContainer) {
+                        animations.slideInUp(reelContainer, { delay: 0.2 });
+                }
+        });
 
 	// Get rarity color
 	function getRarityColor(rarity: CaseItem['rarity']) {

--- a/src/lib/components/battles/BattleRoom.svelte
+++ b/src/lib/components/battles/BattleRoom.svelte
@@ -17,11 +17,11 @@
 		Flame,
 		Currency,
 		Sparkles,
-		CheckCircle,
-		AlertCircle,
-		LiveIndicator,
-		RefreshCw
-	} from '@lucide/svelte';
+                CheckCircle,
+                AlertCircle,
+                RefreshCw,
+                Shield
+        } from '@lucide/svelte';
 	import type { Battle, BattleParticipant, BattleRound, BattlePull, CaseItem } from '$lib/types';
 	
 	// Props using Svelte 5 syntax
@@ -298,12 +298,13 @@
 							<Badge variant="outline" class={getStatusColor(battle.status)}>
 								{battle.status.replace('_', ' ')}
 							</Badge>
-							{#if battleRoom?.isLive}
-								<div class="flex items-center gap-2">
-									<div class="h-2 w-2 bg-emerald-500 rounded-full animate-pulse"></div>
-									<span class="text-sm font-medium text-emerald-400">LIVE</span>
-								</div>
-							{/if}
+                                                        {#if battle?.status === 'in_progress'}
+                                                                <div class="flex items-center gap-2">
+                                                                        <span class="sr-only">Battle status:</span>
+                                                                        <div class="h-2 w-2 rounded-full bg-destructive animate-pulse" aria-hidden="true"></div>
+                                                                        <span class="text-sm font-medium text-destructive">Live</span>
+                                                                </div>
+                                                        {/if}
 						</div>
 					</div>
 				</CardHeader>

--- a/src/lib/components/battles/BattleTotals.svelte
+++ b/src/lib/components/battles/BattleTotals.svelte
@@ -5,7 +5,7 @@
 	import { Progress } from '$lib/components/ui/progress';
 	import { Trophy, Crown, Medal, Users, Currency, TrendingUp, CheckCircle } from '@lucide/svelte';
 	import { onMount } from 'svelte';
-	import { BattleAnimations, createAnimation } from '$lib/utils/animations';
+        import { BattleAnimations, createAnimation } from '$lib/utils/animations';
 	import type { Battle, BattleParticipant } from '$lib/types';
 
 	// Props using Svelte 5 syntax
@@ -22,28 +22,28 @@
 	} = $props();
 
 	// DOM refs for animations
-	let totalsCard: HTMLElement;
-	let potElement: HTMLElement;
-	let winnerElement: HTMLElement;
+        let totalsCard: HTMLElement | null = null;
+        let potElement: HTMLElement | null = null;
+        let winnerElement: HTMLElement | null = null;
 
 	// Animation lifecycle
 	onMount(() => {
 		// Entrance animation for the totals card
-		if (totalsCard) {
-			BattleAnimations.slideInUp(totalsCard, { delay: 0.3 });
-		}
+                if (totalsCard) {
+                        BattleAnimations.slideInUp(totalsCard, { delay: 0.3 });
+                }
 
 		// Animate total pot value
-		if (potElement) {
-			BattleAnimations.countUp(potElement, totalPot, { delay: 0.5 });
-		}
+                if (potElement) {
+                        BattleAnimations.countUp(potElement, totalPot, { delay: 0.5 });
+                }
 	});
 
 	// Animate winner celebration
 	$effect(() => {
-		if (isBattleComplete && winner && winnerElement) {
-			BattleAnimations.celebrateWinner(winnerElement, { delay: 0.2 });
-		}
+                if (isBattleComplete && winner && winnerElement) {
+                        BattleAnimations.celebrateWinner(winnerElement, { delay: 0.2 });
+                }
 	});
 
 	// Format currency
@@ -110,7 +110,8 @@
 	}
 </script>
 
-<Card bind:this={totalsCard}>
+<div class="contents" bind:this={totalsCard}>
+<Card>
 	<CardHeader>
 		<CardTitle class="flex items-center gap-2">
 			<Trophy class="h-5 w-5 text-primary" />
@@ -132,7 +133,7 @@
 					<Currency class="h-5 w-5 text-primary" />
 					<span class="font-semibold text-foreground">Total Pot</span>
 				</div>
-				<span bind:this={potElement} class="text-2xl font-bold text-primary">{formatCurrency(totalPot)}</span>
+                                <span bind:this={potElement} class="text-2xl font-bold text-primary">{formatCurrency(totalPot)}</span>
 			</div>
 		</div>
 
@@ -177,10 +178,10 @@
 								<div class="flex items-center gap-2">
 									<p class="font-semibold text-foreground">{participant.user?.username}</p>
 									{#if isBattleComplete && winner?.user_id === participant.user_id}
-										<Badge variant="default" class="gap-1 animate-bounce">
-											<Crown class="h-3 w-3" />
-											Winner
-										</Badge>
+                                                                        <Badge variant="default" class="gap-1 animate-bounce">
+                                                                                <Crown class="h-3 w-3" />
+                                                                                Winner
+                                                                        </Badge>
 									{/if}
 								</div>
 								<p class="text-sm text-muted-foreground">Player {participant.position}</p>
@@ -272,4 +273,5 @@
 		</div>
 	</CardContent>
 </Card>
+</div>
 

--- a/src/lib/components/battles/RealtimeBattleDemo.svelte
+++ b/src/lib/components/battles/RealtimeBattleDemo.svelte
@@ -44,9 +44,9 @@
 
         // Set up reactive bindings
         $effect(() => {
-          isConnected = room.isConnected;
-          isLoading = room.isLoading;
-          error = room.error;
+          isConnected = room.isConnected();
+          isLoading = room.isLoading();
+          error = room.error();
           currentBattle = room.battle;
           currentRound = room.client.state.currentRound;
         });

--- a/src/lib/components/home/GameGridSection.svelte
+++ b/src/lib/components/home/GameGridSection.svelte
@@ -1,5 +1,6 @@
 ﻿<script lang="ts">
-	import GameCard from './GameCard.svelte';
+        import GameCard from './GameCard.svelte';
+        import type { Snippet } from 'svelte';
 
 	export type GameItem = {
 		id: string;
@@ -10,16 +11,18 @@
 		href?: string;
 	};
 
-	type Props = {
-		title: string;
-		items?: GameItem[];
-		actionLabel?: string;
-	};
+        type Props = {
+                title: string;
+                items?: GameItem[];
+                actionLabel?: string;
+                children?: Snippet;
+        };
 
-	const props: Props = $props();
-	const title = $derived(props.title);
-	const items = $derived(props.items ?? []);
-	const actionLabel = $derived(props.actionLabel ?? 'view all');
+        const props: Props = $props();
+        const title = $derived(props.title);
+        const items = $derived(props.items ?? []);
+        const actionLabel = $derived(props.actionLabel ?? 'view all');
+        const children = $derived(props.children);
 </script>
 
 <section class="space-y-6">
@@ -45,5 +48,5 @@
 			/>
 		{/each}
 	</div>
-	<slot />
+        {@render children?.()}
 </section>

--- a/src/lib/components/home/HeroCarousel.svelte
+++ b/src/lib/components/home/HeroCarousel.svelte
@@ -71,14 +71,15 @@
 			class="flex transition-transform duration-500 ease-in-out h-full"
 			style="transform: translateX(-{currentIndex * 100}%)"
 		>
-			{#each slides as slide, index}
-				<div
-					class="w-full flex-shrink-0"
-					style="background: {slide.background}"
-				>
-					<div class="relative p-6 min-h-[180px] flex flex-col justify-between">
-						<!-- Glass effect -->
-						<div class="absolute inset-0 bg-white/10 backdrop-blur-sm rounded-2xl" />
+                        {#each slides as slide, index}
+                                {@const SlideIcon = slide.icon}
+                                <div
+                                        class="w-full flex-shrink-0"
+                                        style="background: {slide.background}"
+                                >
+                                        <div class="relative p-6 min-h-[180px] flex flex-col justify-between">
+                                                <!-- Glass effect -->
+                                                <div class="absolute inset-0 bg-white/10 backdrop-blur-sm rounded-2xl"></div>
 
 						<div class="relative space-y-4">
 							<!-- Badge -->
@@ -100,10 +101,10 @@
 
 							<!-- CTA section -->
 							<div class="flex items-center justify-between gap-4">
-								<div class="flex items-center gap-2">
-									<svelte:component this={slide.icon} class="h-5 w-5 text-white/90" />
-									<span class="text-white font-semibold text-sm">
-										{slide.highlight}
+                                                                <div class="flex items-center gap-2">
+                                                                        <SlideIcon class="h-5 w-5 text-white/90" />
+                                                                        <span class="text-white font-semibold text-sm">
+                                                                                {slide.highlight}
 									</span>
 								</div>
 								<button

--- a/src/lib/components/home/HomeHero.svelte
+++ b/src/lib/components/home/HomeHero.svelte
@@ -32,22 +32,23 @@
 		return () => stopRotation();
 	});
 
-	const highlightIcon = $derived(() => {
-		switch (promotions[activeIndex]?.tag) {
-			case 'Battles':
-				return Flame;
-			case 'Flash drop':
-				return Timer;
-			default:
-				return Sparkles;
-		}
-	});
+        const highlightIcon = $derived(() => {
+                switch (promotions[activeIndex]?.tag) {
+                        case 'Battles':
+                                return Flame;
+                        case 'Flash drop':
+                                return Timer;
+                        default:
+                                return Sparkles;
+                }
+        });
 </script>
 
 {#if promotions.length}
-	<section
-		class="border-border/70 bg-surface/80 shadow-marketplace-lg relative overflow-hidden rounded-3xl border"
-	>
+        {@const HighlightIcon = highlightIcon}
+        <section
+                class="border-border/70 bg-surface/80 shadow-marketplace-lg relative overflow-hidden rounded-3xl border"
+        >
 		<div class="grid gap-8 lg:grid-cols-[7fr,5fr]">
 			<div
 				class="relative flex min-h-[420px] flex-col justify-between p-8 sm:p-10"
@@ -90,12 +91,12 @@
 				<div
 					class="border-border/40 bg-surface/60 flex flex-wrap items-center justify-between gap-4 rounded-2xl border px-6 py-5 backdrop-blur"
 				>
-					<div class="text-foreground/80 flex items-center gap-3">
-						<span
-							class="border-border/50 bg-surface/40 flex h-11 w-11 items-center justify-center rounded-xl border"
-						>
-							<svelte:component this={highlightIcon} class="h-5 w-5" />
-						</span>
+                                        <div class="text-foreground/80 flex items-center gap-3">
+                                                <span
+                                                        class="border-border/50 bg-surface/40 flex h-11 w-11 items-center justify-center rounded-xl border"
+                                                >
+                                                        <HighlightIcon class="h-5 w-5" />
+                                                </span>
 						<div>
 							<p class="text-muted-foreground text-xs tracking-[0.35em] uppercase">Highlight</p>
 							<p class="text-lg font-semibold">{promotions[activeIndex].highlight}</p>
@@ -157,12 +158,12 @@
 
 				<div class="flex items-center justify-center gap-2">
 					{#each promotions as _, index}
-						<span
-							class={`h-1.5 rounded-full transition-all ${
-								index === activeIndex ? 'bg-primary w-8' : 'bg-border w-3'
-							}`}
-							aria-hidden="true"
-						/>
+                                                <span
+                                                        class={`h-1.5 rounded-full transition-all ${
+                                                                index === activeIndex ? 'bg-primary w-8' : 'bg-border w-3'
+                                                        }`}
+                                                        aria-hidden="true"
+                                                ></span>
 					{/each}
 				</div>
 			</aside>

--- a/src/lib/components/home/LiveDropsTicker.svelte
+++ b/src/lib/components/home/LiveDropsTicker.svelte
@@ -22,8 +22,8 @@
 <section class="w-full overflow-hidden bg-surface/30 backdrop-blur-sm border-y border-border/40">
 	<div class="relative">
 		<!-- Gradient overlays for fade effect -->
-		<div class="absolute left-0 top-0 bottom-0 w-24 bg-gradient-to-r from-background to-transparent z-10 pointer-events-none" />
-		<div class="absolute right-0 top-0 bottom-0 w-24 bg-gradient-to-l from-background to-transparent z-10 pointer-events-none" />
+                <div class="absolute left-0 top-0 bottom-0 w-24 bg-gradient-to-r from-background to-transparent z-10 pointer-events-none"></div>
+                <div class="absolute right-0 top-0 bottom-0 w-24 bg-gradient-to-l from-background to-transparent z-10 pointer-events-none"></div>
 
 		<div class="flex animate-scroll py-3 gap-6">
 			{#each [...drops, ...drops] as drop}

--- a/src/lib/components/home/LiveMarketplaceGrid.svelte
+++ b/src/lib/components/home/LiveMarketplaceGrid.svelte
@@ -53,8 +53,8 @@
 							</span>
 						</div>
 						<div class="relative z-[1] mt-16 text-left">
-							<p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">
-								{item.playersOnline} players
+                                                        <p class="text-muted-foreground text-xs tracking-[0.3em] uppercase">
+                                                                {item.watching} watching
 							</p>
 							<p class="text-foreground text-lg font-semibold">{item.name}</p>
 						</div>
@@ -75,8 +75,8 @@
 						</span>
 						<div>
 							<p class="text-[11px] tracking-[0.3em] uppercase">Watching</p>
-							<p class="text-foreground text-sm font-medium">
-								{item.playersOnline.toLocaleString()} live
+                                                        <p class="text-foreground text-sm font-medium">
+                                                                {item.watching.toLocaleString()} live
 							</p>
 						</div>
 					</div>

--- a/src/lib/components/shell/BottomNav.svelte
+++ b/src/lib/components/shell/BottomNav.svelte
@@ -5,18 +5,22 @@
 	import { Home, Package, Swords, ArrowUpRight, Briefcase } from '@lucide/svelte';
 	import { cn } from '$lib/utils';
 
-	type BottomNavProps = {
-		isAuthenticated?: boolean;
-		class?: string;
-	};
+        type BottomNavProps = {
+                isAuthenticated?: boolean;
+                class?: string;
+        };
 
-	const props = $props<BottomNavProps>();
-	const isAuthenticated = $derived(() => props.isAuthenticated ?? false);
-	const className = $derived(() => props.class ?? '');
+        let { isAuthenticated = false, class: className = '' }: BottomNavProps = $props();
 
-	const pageStore = page;
-	const currentPage = $derived(pageStore);
-	const currentPath = $derived(() => currentPage.url.pathname);
+        let currentPath = $state('');
+
+        $effect(() => {
+                const unsubscribe = page.subscribe(($page) => {
+                        currentPath = $page.url.pathname;
+                });
+
+                return () => unsubscribe();
+        });
 
 	const items = [
 		{ href: '/', label: 'Home', icon: Home },
@@ -36,21 +40,18 @@
 
 <nav
 	aria-label="Mobile navigation"
-	class={cn(
-		'flex items-center justify-between gap-1 px-2 py-2',
-		className
-	)}
+        class={cn('flex items-center justify-between gap-1 px-2 py-2', className)}
 >
 	{#each items as item (item.href)}
 		<button
 			type="button"
 			onclick={() => handleNavigation(item.href)}
 			class={cn(
-				'text-muted-foreground focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium tracking-[0.25em] uppercase transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-				isActiveRoute(item.href)
-					? 'bg-primary/20 text-foreground shadow-marketplace-sm'
-					: 'hover:bg-surface-muted/40 hover:text-foreground'
-			)}
+                                'text-muted-foreground focus-visible:ring-ring/70 focus-visible:ring-offset-background flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium tracking-[0.25em] uppercase transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                                isActiveRoute(item.href)
+                                        ? 'bg-primary/20 text-foreground shadow-marketplace-sm'
+                                        : 'hover:bg-surface-muted/40 hover:text-foreground'
+                        )}
 			aria-pressed={isActiveRoute(item.href)}
 		>
 			<span
@@ -63,9 +64,9 @@
 			>
 				<item.icon class="h-5 w-5" />
 			</span>
-			<span class="leading-tight tracking-normal normal-case">
-				{item.href === '/inventory' ? (isAuthenticated ? 'Inventory' : 'Locker') : item.label}
-			</span>
+                        <span class="leading-tight tracking-normal normal-case">
+                                {item.href === '/inventory' ? (isAuthenticated ? 'Inventory' : 'Locker') : item.label}
+                        </span>
 		</button>
 	{/each}
 </nav>

--- a/src/lib/components/ui/badge.svelte
+++ b/src/lib/components/ui/badge.svelte
@@ -1,25 +1,38 @@
 <script lang="ts">
-	import { cn } from '$lib/utils';
+        import { cn } from '$lib/utils';
 
-	type BadgeVariant = 'default' | 'outline' | 'success' | 'warning' | 'info' | 'destructive';
-	let { variant = 'default' as BadgeVariant, class: className = '', children } = $props();
+        export type BadgeVariant =
+                | 'default'
+                | 'outline'
+                | 'success'
+                | 'warning'
+                | 'info'
+                | 'destructive'
+                | 'secondary';
 
-	const variants: Record<BadgeVariant, string> = {
-		default: 'bg-primary/15 text-primary border border-primary/35',
-		outline: 'border border-border/70 text-muted-foreground',
-		success: 'bg-success/15 text-success border border-success/40',
-		warning: 'bg-warning/15 text-warning-foreground border border-warning/40',
-		info: 'bg-info/15 text-info border border-info/40',
-		destructive: 'bg-destructive/15 text-destructive border border-destructive/40'
-	};
+        let { variant = 'default' as BadgeVariant, class: className = '', children } = $props<{
+                variant?: BadgeVariant;
+                class?: string;
+                children?: () => unknown;
+        }>();
+
+        const variants: Record<BadgeVariant, string> = {
+                default: 'bg-primary/15 text-primary border border-primary/35',
+                outline: 'border border-border/70 text-muted-foreground',
+                success: 'bg-success/15 text-success border border-success/40',
+                warning: 'bg-warning/15 text-warning-foreground border border-warning/40',
+                info: 'bg-info/15 text-info border border-info/40',
+                destructive: 'bg-destructive/15 text-destructive border border-destructive/40',
+                secondary: 'bg-secondary/20 text-secondary-foreground border border-secondary/40'
+        };
 </script>
 
 <span
-	class={cn(
-		'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium tracking-wide uppercase',
-		variants[variant],
-		className
-	)}
+        class={cn(
+                'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium tracking-wide uppercase',
+                variants[variant as BadgeVariant],
+                className
+        )}
 >
-	{@render children?.()}
+        {@render children?.()}
 </span>

--- a/src/lib/components/ui/badge/index.ts
+++ b/src/lib/components/ui/badge/index.ts
@@ -1,2 +1,0 @@
-export { default as Badge } from './badge.svelte';
-export type { BadgeVariant } from './badge.svelte';

--- a/src/lib/components/ui/calendar/calendar.svelte
+++ b/src/lib/components/ui/calendar/calendar.svelte
@@ -1,42 +1,66 @@
 <script lang="ts">
-	import { Calendar as CalendarPrimitive } from "bits-ui";
-	import * as Calendar from "./index.js";
-	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
-	import type { ButtonVariant } from "../button/button.svelte";
-	import { isEqualMonth, type DateValue } from "@internationalized/date";
-	import type { Snippet } from "svelte";
+        import { Calendar as CalendarPrimitive } from "bits-ui";
+        import * as Calendar from "./index.js";
+        import { cn } from "$lib/utils.js";
+        import type { ButtonVariant } from "../button/button.svelte";
+        import { isEqualMonth, type DateValue } from "@internationalized/date";
+        import type { Snippet } from "svelte";
 
-	let {
-		ref = $bindable(null),
-		value = $bindable(),
-		placeholder = $bindable(),
-		class: className,
-		weekdayFormat = "short",
-		buttonVariant = "ghost",
-		captionLayout = "label",
-		locale = "en-US",
-		months: monthsProp,
-		years,
-		monthFormat: monthFormatProp,
-		yearFormat = "numeric",
-		day,
-		disableDaysOutsideMonth = false,
-		...restProps
-	}: WithoutChildrenOrChild<CalendarPrimitive.RootProps> & {
-		buttonVariant?: ButtonVariant;
-		captionLayout?: "dropdown" | "dropdown-months" | "dropdown-years" | "label";
-		months?: CalendarPrimitive.MonthSelectProps["months"];
-		years?: CalendarPrimitive.YearSelectProps["years"];
-		monthFormat?: CalendarPrimitive.MonthSelectProps["monthFormat"];
-		yearFormat?: CalendarPrimitive.YearSelectProps["yearFormat"];
-		day?: Snippet<[{ day: DateValue; outsideMonth: boolean }]>;
-	} = $props();
+        type CalendarRootSlotContext = {
+                months: Array<{ weeks: DateValue[][]; value: DateValue }>;
+                weekdays: string[];
+        };
 
-	const monthFormat = $derived.by(() => {
-		if (monthFormatProp) return monthFormatProp;
-		if (captionLayout.startsWith("dropdown")) return "short";
-		return "long";
-	});
+        type CalendarDaySlotContext = { day: DateValue; outsideMonth: boolean };
+
+        type CalendarRootProps = {
+                ref?: HTMLElement | null;
+                value?: CalendarPrimitive.RootProps["value"];
+                placeholder?: CalendarPrimitive.RootProps["placeholder"];
+                class?: string;
+                weekdayFormat?: "narrow" | "short" | "long";
+                buttonVariant?: ButtonVariant;
+                captionLayout?: "dropdown" | "dropdown-months" | "dropdown-years" | "label";
+                locale?: string;
+                months?: CalendarPrimitive.MonthSelectProps["months"];
+                years?: CalendarPrimitive.YearSelectProps["years"];
+                monthFormat?: CalendarPrimitive.MonthSelectProps["monthFormat"];
+                yearFormat?: CalendarPrimitive.YearSelectProps["yearFormat"];
+                day?: Snippet<[CalendarDaySlotContext]>;
+                disableDaysOutsideMonth?: boolean;
+                children?: Snippet<[CalendarRootSlotContext]>;
+                [key: string]: unknown;
+        };
+
+        let {
+                ref = $bindable<HTMLElement | null>(null),
+                value = $bindable<CalendarPrimitive.RootProps["value"] | undefined>(),
+                placeholder = $bindable<CalendarPrimitive.RootProps["placeholder"] | undefined>(),
+                class: className = '',
+                weekdayFormat = "short",
+                buttonVariant = "ghost",
+                captionLayout = "label",
+                locale = "en-US",
+                months: monthsProp,
+                years,
+                monthFormat: monthFormatProp,
+                yearFormat = "numeric",
+                day,
+                disableDaysOutsideMonth = false,
+                children,
+                ...restProps
+        }: CalendarRootProps = $props();
+
+        const forwardedProps = {
+                type: 'single',
+                ...restProps
+        } as Record<string, unknown>;
+
+        const monthFormatValue = $derived.by(() => {
+                if (monthFormatProp) return monthFormatProp;
+                if (captionLayout.startsWith("dropdown")) return "short";
+                return "long";
+        });
 </script>
 
 <!--
@@ -44,72 +68,72 @@ Discriminated Unions + Destructing (required for bindable) do not
 get along, so we shut typescript up by casting `value` to `never`.
 -->
 <CalendarPrimitive.Root
-	bind:value={value as never}
-	bind:ref
-	bind:placeholder
-	{weekdayFormat}
-	{disableDaysOutsideMonth}
-	class={cn(
-		"bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
-		className
-	)}
-	{locale}
-	{monthFormat}
-	{yearFormat}
-	{...restProps}
+        bind:value={value as never}
+        bind:ref
+        bind:placeholder
+        {weekdayFormat}
+        {disableDaysOutsideMonth}
+        class={cn(
+                "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+                className
+        )}
+        {locale}
+        monthFormat={monthFormatValue}
+        {yearFormat}
+        {...forwardedProps}
 >
-	{#snippet children({ months, weekdays })}
-		<Calendar.Months>
-			<Calendar.Nav>
-				<Calendar.PrevButton variant={buttonVariant} />
-				<Calendar.NextButton variant={buttonVariant} />
-			</Calendar.Nav>
-			{#each months as month, monthIndex (month)}
-				<Calendar.Month>
-					<Calendar.Header>
-						<Calendar.Caption
-							{captionLayout}
-							months={monthsProp}
-							{monthFormat}
-							{years}
-							{yearFormat}
-							month={month.value}
-							bind:placeholder
-							{locale}
-							{monthIndex}
-						/>
-					</Calendar.Header>
-					<Calendar.Grid>
-						<Calendar.GridHead>
-							<Calendar.GridRow class="select-none">
-								{#each weekdays as weekday (weekday)}
-									<Calendar.HeadCell>
-										{weekday.slice(0, 2)}
-									</Calendar.HeadCell>
-								{/each}
-							</Calendar.GridRow>
-						</Calendar.GridHead>
-						<Calendar.GridBody>
-							{#each month.weeks as weekDates (weekDates)}
-								<Calendar.GridRow class="mt-2 w-full">
-									{#each weekDates as date (date)}
-										<Calendar.Cell {date} month={month.value}>
-											{#if day}
-												{@render day({
-													day: date,
-													outsideMonth: !isEqualMonth(date, month.value),
-												})}
-											{:else}
-												<Calendar.Day />
-											{/if}
-										</Calendar.Cell>
-									{/each}
-								</Calendar.GridRow>
-							{/each}
-						</Calendar.GridBody>
-					</Calendar.Grid>
-				</Calendar.Month>
-			{/each}
-		</Calendar.Months>
-	{/snippet}
+        {#snippet children({ months, weekdays })}
+                <Calendar.Months>
+                        <Calendar.Nav>
+                                <Calendar.PrevButton variant={buttonVariant} />
+                                <Calendar.NextButton variant={buttonVariant} />
+                        </Calendar.Nav>
+                        {#each months as month, monthIndex (month)}
+                                <Calendar.Month>
+                                        <Calendar.Header>
+                                                <Calendar.Caption
+                                                        {captionLayout}
+                                                        months={monthsProp}
+                                                        monthFormat={monthFormatValue}
+                                                        {years}
+                                                        {yearFormat}
+                                                        month={month.value}
+                                                        bind:placeholder
+                                                        {locale}
+                                                        {monthIndex}
+                                                />
+                                        </Calendar.Header>
+                                        <Calendar.Grid>
+                                                <Calendar.GridHead>
+                                                        <Calendar.GridRow class="select-none">
+                                                                {#each weekdays as weekday (weekday)}
+                                                                        <Calendar.HeadCell>
+                                                                                {weekday.slice(0, 2)}
+                                                                        </Calendar.HeadCell>
+                                                                {/each}
+                                                        </Calendar.GridRow>
+                                                </Calendar.GridHead>
+                                                <Calendar.GridBody>
+                                                        {#each month.weeks as weekDates (weekDates)}
+                                                                <Calendar.GridRow class="mt-2 w-full">
+                                                                        {#each weekDates as date (date)}
+                                                                                <Calendar.Cell {date} month={month.value}>
+                                                                                        {#if day}
+                                                                                                {@render day({
+                                                                                                        day: date,
+                                                                                                        outsideMonth: !isEqualMonth(date, month.value),
+                                                                                                })}
+                                                                                        {:else}
+                                                                                                <Calendar.Day />
+                                                                                        {/if}
+                                                                                </Calendar.Cell>
+                                                                        {/each}
+                                                                </Calendar.GridRow>
+                                                        {/each}
+                                                </Calendar.GridBody>
+                                        </Calendar.Grid>
+                                </Calendar.Month>
+                        {/each}
+                </Calendar.Months>
+        {/snippet}
 </CalendarPrimitive.Root>

--- a/src/lib/components/ui/card.svelte
+++ b/src/lib/components/ui/card.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-	import { cn } from '$lib/utils';
+        import { cn } from '$lib/utils';
 
-	let { class: className = '', children } = $props();
+        let { class: className = '', children } = $props();
 </script>
 
 <div
-	class={cn(
-		'border-border/60 bg-card text-card-foreground shadow-marketplace-sm duration-subtle ease-market-ease hover:border-border/80 hover:shadow-marketplace-md rounded-lg border transition-colors',
-		className
-	)}
+        class={cn(
+                'border-border/60 bg-card text-card-foreground shadow-marketplace-sm duration-subtle ease-market-ease hover:border-border/80 hover:shadow-marketplace-md rounded-lg border transition-colors',
+                className
+        )}
 >
-	{@render children?.()}
+        {@render children?.()}
 </div>

--- a/src/lib/components/ui/card/index.ts
+++ b/src/lib/components/ui/card/index.ts
@@ -1,6 +1,0 @@
-export { default as Card } from './card.svelte';
-export { default as CardHeader } from './card-header.svelte';
-export { default as CardFooter } from './card-footer.svelte';
-export { default as CardTitle } from './card-title.svelte';
-export { default as CardDescription } from './card-description.svelte';
-export { default as CardContent } from './card-content.svelte';

--- a/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
-	import CheckIcon from "@lucide/svelte/icons/check";
-	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
-	import type { Snippet } from "svelte";
+        import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+        import CheckIcon from "@lucide/svelte/icons/check";
+        import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+        type ContextMenuCheckboxContext = { checked: boolean; indeterminate: boolean };
 
 	let {
 		ref = $bindable(null),
@@ -11,9 +12,10 @@
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {
-		children?: Snippet;
-	} = $props();
+        }: WithoutChildrenOrChild<
+                ContextMenuPrimitive.CheckboxItemProps,
+                [ContextMenuCheckboxContext]
+        > = $props();
 </script>
 
 <ContextMenuPrimitive.CheckboxItem
@@ -27,12 +29,14 @@
 	)}
 	{...restProps}
 >
-	{#snippet children({ checked })}
-		<span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-			{#if checked}
-				<CheckIcon class="size-4" />
-			{/if}
-		</span>
-		{@render childrenProp?.()}
-	{/snippet}
+        {#snippet children({ checked, indeterminate })}
+                <span class="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+                        {#if indeterminate}
+                                <CheckIcon class="size-4 opacity-50" />
+                        {:else if checked}
+                                <CheckIcon class="size-4" />
+                        {/if}
+                </span>
+                {@render childrenProp?.({ checked, indeterminate })}
+        {/snippet}
 </ContextMenuPrimitive.CheckboxItem>

--- a/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-	import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
-	import CircleIcon from "@lucide/svelte/icons/circle";
-	import { cn, type WithoutChild } from "$lib/utils.js";
+        import { ContextMenu as ContextMenuPrimitive } from "bits-ui";
+        import CircleIcon from "@lucide/svelte/icons/circle";
+        import { cn, type WithoutChild } from "$lib/utils.js";
+
+        type ContextMenuRadioContext = { checked: boolean };
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<ContextMenuPrimitive.RadioItemProps> = $props();
+        }: WithoutChild<ContextMenuPrimitive.RadioItemProps, [ContextMenuRadioContext]> = $props();
 </script>
 
 <ContextMenuPrimitive.RadioItem

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
-	import CheckIcon from "@lucide/svelte/icons/check";
-	import MinusIcon from "@lucide/svelte/icons/minus";
-	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
-	import type { Snippet } from "svelte";
+        import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+        import CheckIcon from "@lucide/svelte/icons/check";
+        import MinusIcon from "@lucide/svelte/icons/minus";
+        import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+        type DropdownMenuCheckboxContext = { checked: boolean; indeterminate: boolean };
 
 	let {
 		ref = $bindable(null),
@@ -12,9 +13,10 @@
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChildrenOrChild<DropdownMenuPrimitive.CheckboxItemProps> & {
-		children?: Snippet;
-	} = $props();
+        }: WithoutChildrenOrChild<
+                DropdownMenuPrimitive.CheckboxItemProps,
+                [DropdownMenuCheckboxContext]
+        > = $props();
 </script>
 
 <DropdownMenuPrimitive.CheckboxItem
@@ -36,6 +38,6 @@
 				<CheckIcon class={cn("size-4", !checked && "text-transparent")} />
 			{/if}
 		</span>
-		{@render childrenProp?.()}
-	{/snippet}
+                {@render childrenProp?.({ checked, indeterminate })}
+        {/snippet}
 </DropdownMenuPrimitive.CheckboxItem>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
-	import CircleIcon from "@lucide/svelte/icons/circle";
-	import { cn, type WithoutChild } from "$lib/utils.js";
+        import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+        import CircleIcon from "@lucide/svelte/icons/circle";
+        import { cn, type WithoutChild } from "$lib/utils.js";
+
+        type DropdownMenuRadioContext = { checked: boolean };
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<DropdownMenuPrimitive.RadioItemProps> = $props();
+        }: WithoutChild<DropdownMenuPrimitive.RadioItemProps, [DropdownMenuRadioContext]> = $props();
 </script>
 
 <DropdownMenuPrimitive.RadioItem

--- a/src/lib/components/ui/form/form-element-field.svelte
+++ b/src/lib/components/ui/form/form-element-field.svelte
@@ -1,8 +1,15 @@
 <script lang="ts" generics="T extends Record<string, unknown>, U extends FormPathLeaves<T>">
-	import * as FormPrimitive from "formsnap";
-	import type { FormPathLeaves } from "sveltekit-superforms";
-	import type { HTMLAttributes } from "svelte/elements";
-	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
+        import * as FormPrimitive from "formsnap";
+        import type { FormPathLeaves } from "sveltekit-superforms";
+        import type { HTMLAttributes } from "svelte/elements";
+        import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
+
+        type FormElementFieldSlotContext<Value> = {
+                constraints: unknown;
+                errors: unknown;
+                tainted: boolean;
+                value: Value;
+        };
 
 	let {
 		ref = $bindable(null),
@@ -11,8 +18,10 @@
 		name,
 		children: childrenProp,
 		...restProps
-	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> &
-		FormPrimitive.ElementFieldProps<T, U> = $props();
+        }: WithoutChildren<
+                WithElementRef<HTMLAttributes<HTMLDivElement>>,
+                [FormElementFieldSlotContext<T[U]>]
+        > & FormPrimitive.ElementFieldProps<T, U> = $props();
 </script>
 
 <FormPrimitive.ElementField {form} {name}>

--- a/src/lib/components/ui/form/form-field-errors.svelte
+++ b/src/lib/components/ui/form/form-field-errors.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import * as FormPrimitive from "formsnap";
-	import { cn, type WithoutChild } from "$lib/utils.js";
+        import { cn, type WithoutChild } from "$lib/utils.js";
+
+        type FieldErrorsSlotContext = {
+                errors: string[];
+                errorProps: Record<string, unknown>;
+        };
 
 	let {
 		ref = $bindable(null),
@@ -8,9 +13,9 @@
 		errorClasses,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<FormPrimitive.FieldErrorsProps> & {
-		errorClasses?: string | undefined | null;
-	} = $props();
+        }: WithoutChild<FormPrimitive.FieldErrorsProps, [FieldErrorsSlotContext]> & {
+                errorClasses?: string | undefined | null;
+        } = $props();
 </script>
 
 <FormPrimitive.FieldErrors

--- a/src/lib/components/ui/form/form-field.svelte
+++ b/src/lib/components/ui/form/form-field.svelte
@@ -1,8 +1,15 @@
 <script lang="ts" generics="T extends Record<string, unknown>, U extends FormPath<T>">
-	import * as FormPrimitive from "formsnap";
-	import type { FormPath } from "sveltekit-superforms";
-	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+        import * as FormPrimitive from "formsnap";
+        import type { FormPath } from "sveltekit-superforms";
+        import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
+        import type { HTMLAttributes } from "svelte/elements";
+
+        type FormFieldSlotContext<Value> = {
+                constraints: unknown;
+                errors: unknown;
+                tainted: boolean;
+                value: Value;
+        };
 
 	let {
 		ref = $bindable(null),
@@ -11,8 +18,11 @@
 		name,
 		children: childrenProp,
 		...restProps
-	}: FormPrimitive.FieldProps<T, U> &
-		WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
+        }: FormPrimitive.FieldProps<T, U> &
+                WithoutChildren<
+                        WithElementRef<HTMLAttributes<HTMLDivElement>>,
+                        [FormFieldSlotContext<T[U]>]
+                > = $props();
 </script>
 
 <FormPrimitive.Field {form} {name}>

--- a/src/lib/components/ui/index.ts
+++ b/src/lib/components/ui/index.ts
@@ -19,6 +19,7 @@ export * as Avatar from './avatar/index.js';
 
 // Badge
 export { default as Badge } from './badge.svelte';
+export type { BadgeVariant } from './badge.svelte';
 
 // Breadcrumb
 export * as Breadcrumb from './breadcrumb/index.js';

--- a/src/lib/components/ui/menubar/menubar-checkbox-item.svelte
+++ b/src/lib/components/ui/menubar/menubar-checkbox-item.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import CheckIcon from "@lucide/svelte/icons/check";
-	import MinusIcon from "@lucide/svelte/icons/minus";
-	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
-	import type { Snippet } from "svelte";
+        import { Menubar as MenubarPrimitive } from "bits-ui";
+        import CheckIcon from "@lucide/svelte/icons/check";
+        import MinusIcon from "@lucide/svelte/icons/minus";
+        import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+        type MenubarCheckboxContext = { checked: boolean; indeterminate: boolean };
 
 	let {
 		ref = $bindable(null),
@@ -12,9 +13,10 @@
 		indeterminate = $bindable(false),
 		children: childrenProp,
 		...restProps
-	}: WithoutChildrenOrChild<MenubarPrimitive.CheckboxItemProps> & {
-		children?: Snippet;
-	} = $props();
+        }: WithoutChildrenOrChild<
+                MenubarPrimitive.CheckboxItemProps,
+                [MenubarCheckboxContext]
+        > = $props();
 </script>
 
 <MenubarPrimitive.CheckboxItem
@@ -36,6 +38,6 @@
 				<CheckIcon class={cn("size-4", !checked && "text-transparent")} />
 			{/if}
 		</span>
-		{@render childrenProp?.()}
-	{/snippet}
+                {@render childrenProp?.({ checked, indeterminate })}
+        {/snippet}
 </MenubarPrimitive.CheckboxItem>

--- a/src/lib/components/ui/menubar/menubar-radio-item.svelte
+++ b/src/lib/components/ui/menubar/menubar-radio-item.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import CircleIcon from "@lucide/svelte/icons/circle";
-	import { cn, type WithoutChild } from "$lib/utils.js";
+        import { Menubar as MenubarPrimitive } from "bits-ui";
+        import CircleIcon from "@lucide/svelte/icons/circle";
+        import { cn, type WithoutChild } from "$lib/utils.js";
+
+        type MenubarRadioContext = { checked: boolean };
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<MenubarPrimitive.RadioItemProps> = $props();
+        }: WithoutChild<MenubarPrimitive.RadioItemProps, [MenubarRadioContext]> = $props();
 </script>
 
 <MenubarPrimitive.RadioItem

--- a/src/lib/components/ui/navigation-menu/index.ts
+++ b/src/lib/components/ui/navigation-menu/index.ts
@@ -1,15 +1,2 @@
-import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-	return twMerge(clsx(inputs));
-}
-
 export { default as NavigationMenu } from './navigation-menu.svelte';
-export { default as NavigationMenuContent } from './navigation-menu-content.svelte';
-export { default as NavigationMenuItem } from './navigation-menu-item.svelte';
-export { default as NavigationMenuLink } from './navigation-menu-link.svelte';
-export { default as NavigationMenuList } from './navigation-menu-list.svelte';
-export { default as NavigationMenuTrigger } from './navigation-menu-trigger.svelte';
-export { default as NavigationMenuViewport } from './navigation-menu-viewport.svelte';
 export * from './types';

--- a/src/lib/components/ui/navigation-menu/navigation-menu.svelte
+++ b/src/lib/components/ui/navigation-menu/navigation-menu.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { cn } from '$lib/utils';
-	import type { NavigationMenuProps } from './types';
+        import { cn } from '$lib/utils';
+        import type { NavigationMenuProps } from './types';
 
-	let { class: className, ...rest }: NavigationMenuProps = $props();
+        let { class: className, children, ...rest }: NavigationMenuProps = $props();
 </script>
 
-<nav { ...rest } class={cn('relative flex w-full flex-1 items-center justify-between', className)}>
-	<slot />
+<nav {...rest} class={cn('relative flex w-full flex-1 items-center justify-between', className)}>
+        {@render children?.()}
 </nav>

--- a/src/lib/components/ui/navigation-menu/types.ts
+++ b/src/lib/components/ui/navigation-menu/types.ts
@@ -1,5 +1,8 @@
+import type { Snippet } from 'svelte';
+
 export type NavigationMenuProps = {
-	class?: string;
+        class?: string;
+        children?: Snippet;
 };
 
 export type NavigationMenuContentProps = {

--- a/src/lib/components/ui/select/select-item.svelte
+++ b/src/lib/components/ui/select/select-item.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
 	import CheckIcon from "@lucide/svelte/icons/check";
-	import { Select as SelectPrimitive } from "bits-ui";
-	import { cn, type WithoutChild } from "$lib/utils.js";
+        import { Select as SelectPrimitive } from "bits-ui";
+        import { cn, type WithoutChild } from "$lib/utils.js";
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		value,
-		label,
-		children: childrenProp,
-		...restProps
-	}: WithoutChild<SelectPrimitive.ItemProps> = $props();
+        type SelectItemSlotContext = { selected: boolean; highlighted: boolean };
+
+        let {
+                ref = $bindable(null),
+                class: className,
+                value,
+                label,
+                children: childrenProp,
+                ...restProps
+        }: WithoutChild<SelectPrimitive.ItemProps, [SelectItemSlotContext]> = $props();
 </script>
 
 <SelectPrimitive.Item

--- a/src/lib/components/ui/slider/slider.svelte
+++ b/src/lib/components/ui/slider/slider.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
-	import { Slider as SliderPrimitive } from "bits-ui";
-	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+        import { Slider as SliderPrimitive } from "bits-ui";
+        import { cn } from "$lib/utils.js";
+        import type { Snippet } from "svelte";
 
-	let {
-		ref = $bindable(null),
-		value = $bindable(),
-		orientation = "horizontal",
-		class: className,
-		...restProps
-	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> = $props();
+        type SliderSlotContext = { thumbs: number[] };
+
+        type SliderProps = Omit<SliderPrimitive.RootProps, "children"> & {
+                children?: Snippet<[SliderSlotContext]>;
+        };
+
+        let {
+                ref = $bindable(null),
+                value = $bindable(),
+                orientation = "horizontal",
+                class: className,
+                children: _children,
+                ...restProps
+        }: SliderProps = $props();
+
+        const forwardedProps = restProps as SliderPrimitive.RootProps;
 </script>
 
 <!--
@@ -20,11 +30,11 @@ get along, so we shut typescript up by casting `value` to `never`.
 	bind:value={value as never}
 	data-slot="slider"
 	{orientation}
-	class={cn(
-		"relative flex w-full touch-none select-none items-center data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col data-[disabled]:opacity-50",
-		className
-	)}
-	{...restProps}
+        class={cn(
+                "relative flex w-full touch-none select-none items-center data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col data-[disabled]:opacity-50",
+                className
+        )}
+        {...forwardedProps}
 >
 	{#snippet children({ thumbs })}
 		<span

--- a/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/src/lib/components/ui/tabs/tabs-content.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-	import { cn } from '$lib/utils';
-	import { useTabsContext } from './context';
-	import { derived } from 'svelte/store';
+        import { cn } from '$lib/utils';
+        import { useTabsContext } from './context';
+        import { derived } from 'svelte/store';
+        import type { Snippet } from 'svelte';
 
-	let { value, class: className = '', children } = $props<{ value: string; class?: string; children?: Snippet }>();
+        let { value, class: className = '', children } = $props<{
+                value: string;
+                class?: string;
+                children?: Snippet;
+        }>();
 
 	const { value: store } = useTabsContext();
 	const selected = derived(store, ($value) => $value === value);

--- a/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
-	import { cn } from '$lib/utils';
-	import { useTabsContext } from './context';
-	import { derived } from 'svelte/store';
+        import { cn } from '$lib/utils';
+        import { useTabsContext } from './context';
+        import { derived } from 'svelte/store';
+        import type { Snippet } from 'svelte';
 
 	let {
 		value,
 		class: className = '',
 		disabled = false,
 		children
-	} = $props<{ value: string; class?: string; disabled?: boolean; children?: Snippet }>();
+        } = $props<{
+                value: string;
+                class?: string;
+                disabled?: boolean;
+                children?: Snippet;
+        }>();
 
 	const { value: store, setValue } = useTabsContext();
 	const selected = derived(store, ($value) => $value === value);

--- a/src/lib/components/ui/tabs/tabs.svelte
+++ b/src/lib/components/ui/tabs/tabs.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { cn } from '$lib/utils';
-	import { writable } from 'svelte/store';
-	import { initTabsContext } from './context';
+        import { cn } from '$lib/utils';
+        import { writable } from 'svelte/store';
+        import { initTabsContext } from './context';
+        import type { Snippet } from 'svelte';
 
 	let {
 		value = $bindable(''),

--- a/src/lib/config/limits.ts
+++ b/src/lib/config/limits.ts
@@ -279,15 +279,3 @@ export class LimitValidator {
 // Legacy export for backward compatibility
 export const LIMITS = MONETARY_LIMITS;
 
-// Export all configuration objects
-export {
-  MONETARY_LIMITS,
-  BATTLE_LIMITS,
-  TIER_LIMITS,
-  RATE_LIMITS,
-  COLLUSION_THRESHOLDS,
-  ECONOMIC_CONTROLS,
-  MODE_LIMITS,
-  TIME_RESTRICTIONS,
-};
-

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,12 +3,8 @@
 // Enhanced UI Components
 export { default as LoadingStates } from './components/LoadingStates.svelte';
 export { default as MicroInteractions } from './components/MicroInteractions.svelte';
-export {
-	default as ToastNotifications,
-	toasts,
-	addToast,
-	removeToast
-} from './components/ToastNotifications.svelte';
+export { default as ToastNotifications } from './components/ToastNotifications.svelte';
+export { toasts, addToast, removeToast } from './components/ToastNotifications.svelte';
 export type { Toast } from './components/ToastNotifications.svelte';
 
 // Enhanced AuthButton

--- a/src/lib/paraglide/messages.d.ts
+++ b/src/lib/paraglide/messages.d.ts
@@ -1,0 +1,5 @@
+export type HelloWorldParams = { name: string };
+
+export const m: {
+        hello_world(params: HelloWorldParams): string;
+};

--- a/src/lib/paraglide/runtime.ts
+++ b/src/lib/paraglide/runtime.ts
@@ -1,0 +1,23 @@
+export type Locale = string;
+
+let currentLocale: Locale = 'en';
+
+export function setLocale(locale: Locale) {
+        currentLocale = locale;
+        if (typeof document !== 'undefined') {
+                document.documentElement.lang = locale;
+        }
+        return locale;
+}
+
+export function getLocale(): Locale {
+        return currentLocale;
+}
+
+export function trackMessageCall(_key: string, _locale?: string): void {
+        // Stubbed telemetry hook for generated paraglide messages
+}
+
+export const experimentalMiddlewareLocaleSplitting = false;
+
+export const isServer = typeof window === 'undefined';

--- a/src/lib/paraglide/server.ts
+++ b/src/lib/paraglide/server.ts
@@ -1,0 +1,6 @@
+export type ParaglideHandler = (context: { request: Request; locale: string }) => Response | Promise<Response>;
+
+export function paraglideMiddleware(request: Request, handler: ParaglideHandler) {
+        const locale = request.headers.get('accept-language')?.split(',')[0]?.trim() || 'en';
+        return handler({ request, locale });
+}

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -93,7 +93,7 @@ export class BattleRealtimeClient {
       this.setupChannelHandlers();
 
       // Subscribe to the channel
-      const subscription = await this.channel.subscribe((status) => {
+      await this.channel.subscribe((status) => {
         console.log(`Battle channel ${channelName} status:`, status);
 
         if (status === 'SUBSCRIBED') {
@@ -103,7 +103,7 @@ export class BattleRealtimeClient {
         }
       });
 
-      return subscription === 'SUBSCRIBED';
+      return true;
     } catch (error) {
       this.handleError(error);
       return false;
@@ -306,8 +306,9 @@ export class BattleRealtimeClient {
       if (this.channel && this.state.isConnected) {
         // Send ping to keep connection alive
         this.channel.send({
-          type: 'heartbeat',
-          timestamp: Date.now()
+          type: 'broadcast',
+          event: 'heartbeat',
+          payload: { timestamp: Date.now() }
         });
       }
     }, 30000); // 30 seconds
@@ -518,6 +519,4 @@ export function formatBattleEvent(event: BattleEvent): string {
   }
 }
 
-// Export types for external use
-export type { BattleConnectionState, BattleRealtimeClient };
 

--- a/src/lib/stores/homepage.ts
+++ b/src/lib/stores/homepage.ts
@@ -47,11 +47,12 @@ export type RainPot = {
 };
 
 export type CommunityMessage = {
-	id: string;
-	username: string;
-	message: string;
-	timestamp: string;
-	badge?: 'vip' | 'staff' | 'pro';
+        id: string;
+        username: string;
+        message: string;
+        timestamp: string;
+        badge?: 'vip' | 'staff' | 'pro';
+        avatar?: string | null;
 };
 
 export const heroPromotions = readable<HeroPromotion[]>([

--- a/src/lib/stores/toasts.ts
+++ b/src/lib/stores/toasts.ts
@@ -1,0 +1,33 @@
+import { writable } from 'svelte/store';
+
+export interface Toast {
+        id: string;
+        type: 'success' | 'error' | 'info' | 'warning';
+        title: string;
+        message?: string;
+        duration?: number;
+        action?: { label: string; onClick: () => void };
+}
+
+export const toasts = writable<Toast[]>([]);
+
+export function addToast(toast: Omit<Toast, 'id'>) {
+        const id = Math.random().toString(36).slice(2);
+        const newToast: Toast = {
+                id,
+                duration: 5000,
+                ...toast
+        };
+
+        toasts.update((list) => [...list, newToast]);
+
+        if (newToast.duration && newToast.duration > 0) {
+                setTimeout(() => removeToast(id), newToast.duration);
+        }
+
+        return id;
+}
+
+export function removeToast(id: string) {
+        toasts.update((list) => list.filter((toast) => toast.id !== id));
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,8 +2,9 @@ export interface UserProfile {
 	user_id: string;
 	steam_id: string;
 	username: string;
-	avatar_url?: string;
-	steam_profile_url?: string;
+        avatar_url?: string;
+        steam_profile_url?: string;
+        country?: string | null;
 	total_wagered?: number;
 	total_profit?: number;
 	win_rate?: number;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,16 +12,16 @@ export type WithElementRef<T, E = HTMLElement> = T & {
 	ref?: E | null;
 };
 
-export type WithoutChildren<T> = Omit<T, 'children'> & {
-	children?: Snippet;
+export type WithoutChildren<T, TArgs extends any[] = []> = Omit<T, 'children'> & {
+        children?: Snippet<TArgs>;
 };
 
-export type WithoutChild<T> = Omit<T, 'children'> & {
-	children?: Snippet;
+export type WithoutChild<T, TArgs extends any[] = []> = Omit<T, 'children'> & {
+        children?: Snippet<TArgs>;
 };
 
-export type WithoutChildrenOrChild<T> = Omit<T, 'children'> & {
-	children?: Snippet;
+export type WithoutChildrenOrChild<T, TArgs extends any[] = []> = Omit<T, 'children'> & {
+        children?: Snippet<TArgs>;
 };
 
 // General utility functions can be added here as needed

--- a/src/lib/utils/animations.ts
+++ b/src/lib/utils/animations.ts
@@ -139,8 +139,8 @@ export class BattleAnimations {
 	}
 
 	// Counting animation for numbers
-	static countUp(element: HTMLElement, endValue: number, config: AnimationConfig = {}): gsap.core.Tween {
-		const { duration = 1, delay = 0, ease = 'power2.out' } = config;
+        static countUp(element: HTMLElement, endValue: number, config: AnimationConfig = {}): gsap.core.Tween {
+                const { duration = 1, delay = 0, ease = 'power2.out' } = config;
 
 		const startValue = 0;
 		const obj = { value: startValue };
@@ -170,14 +170,30 @@ export class BattleAnimations {
 	static spin(element: HTMLElement, config: AnimationConfig = {}): gsap.core.Tween {
 		const { duration = 1, repeat = -1 } = config;
 
-		return gsap.to(element, {
-			rotation: 360,
-			duration,
-			repeat,
-			ease: 'none',
-			transformOrigin: 'center center'
-		});
-	}
+                return gsap.to(element, {
+                        rotation: 360,
+                        duration,
+                        repeat,
+                        ease: 'none',
+                        transformOrigin: 'center center'
+                });
+        }
+
+        static slideInUp(element: HTMLElement, config: AnimationConfig = {}): gsap.core.Tween {
+                const { duration = DEFAULTS.duration, delay = 0, ease = DEFAULTS.ease } = config;
+
+                return gsap.fromTo(
+                        element,
+                        { y: 40, opacity: 0 },
+                        {
+                                y: 0,
+                                opacity: 1,
+                                duration,
+                                delay,
+                                ease
+                        }
+                );
+        }
 
 	// Glow/Pulse animation for rare items
 	static glow(element: HTMLElement, config: AnimationConfig = {}): gsap.core.Tween {

--- a/tasks.md
+++ b/tasks.md
@@ -18,6 +18,8 @@ This file now tracks project-wide execution. See also: docs/roadmap.md
   - Logging schema, correlation IDs; basic metrics; RLS review; abuse gates
 - [ ] P4 — Core Features
   - Community Pots (MVP), Marketplace, Case Battles wiring to spec
+    - [x] Draft module PRD for Marketplace (docs/product/specs/marketplace.md)
+    - [x] Draft module PRD for Community Pots (docs/product/specs/community-pots.md)
 - [ ] P5 — UX & A11y
   - Component taxonomy, tokens, keyboard/reduced motion, contrast
 - [ ] P6 — Release & QA


### PR DESCRIPTION
## Summary
- centralize toast state in a reusable store and update notifications to use derived icons
- tighten case battle UI interactions with consistent event handling, live status rendering, and entrance animations
- stub paraglide runtime exports and add slideInUp animation helper for smoother transitions

## Testing
- `pnpm run check` *(fails: remaining Svelte/TS errors across UI and realtime modules)*
- `pnpm lint` *(fails: repo-wide Prettier/ESLint backlog)*
- `pnpm test -- --run` *(fails: vitest browser runner dependency resolution)*


------
https://chatgpt.com/codex/tasks/task_e_68df14bc8c408322ba8cbec3269ac88d